### PR TITLE
happy birthday kmc

### DIFF
--- a/_maps/map_files/Pegasus/pegasus1.dmm
+++ b/_maps/map_files/Pegasus/pegasus1.dmm
@@ -1,32 +1,27 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame2/central)
 "aaO" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame1/central)
 "aaX" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -62,9 +57,7 @@
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "acb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -100,15 +93,13 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/engine/break_room)
@@ -159,9 +150,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "aev" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -178,7 +167,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/sign/ship/nosmoking{
 	dir = 8;
-	icon_state = "nosmoking";
 	pixel_x = 32
 	},
 /turf/open/floor/monotile/dark,
@@ -251,15 +239,11 @@
 /area/engine/engine_room)
 "ahR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame1/central)
 "aiq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -270,12 +254,10 @@
 	req_access_txt = "20"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
@@ -363,15 +345,13 @@
 "alf" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -400,6 +380,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "amw" = (
@@ -434,10 +415,10 @@
 /area/nsv/briefingroom)
 "anN" = (
 /obj/machinery/atmospherics/components/binary/pump/layer3{
-	name = "Pure -> Waste"
+	name = "Pure to Waste"
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Pure -> Space"
+	name = "Pure to Space"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -516,17 +497,14 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "aqM" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/science/mixing)
@@ -540,13 +518,15 @@
 /turf/open/floor/monotile,
 /area/security/warden)
 "asf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/frame2/central)
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/frame3/central)
 "asv" = (
 /obj/machinery/atmospherics/pipe/simple/brown/visible/layer3{
 	dir = 4
@@ -565,9 +545,7 @@
 	},
 /obj/item/multitool,
 /obj/item/clothing/glasses/meson,
-/obj/machinery/computer/lore_terminal{
-	pixel_y = 26
-	},
+/obj/machinery/computer/lore_terminal,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -606,8 +584,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
@@ -689,12 +666,10 @@
 	pixel_y = 26
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "avD" = (
 /obj/item/fighter_component/engine/light/t1,
 /turf/open/floor/monotile,
@@ -707,8 +682,7 @@
 "avS" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -738,8 +712,7 @@
 "awR" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -786,8 +759,7 @@
 "axI" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -825,6 +797,13 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/nsv/deck1/starboard)
+"azt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/security/prison)
 "azE" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -888,9 +867,7 @@
 /obj/item/radio/intercom/directional/east,
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet/red,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "aCi" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -908,9 +885,6 @@
 	pixel_y = 3
 	},
 /obj/item/stock_parts/matter_bin,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
 /turf/open/floor/monotile/dark,
 /area/science/lab)
 "aCk" = (
@@ -924,9 +898,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "aCu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -941,9 +913,7 @@
 /area/maintenance/nsv/deck1/port)
 "aCI" = (
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "aCK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -1004,8 +974,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
@@ -1056,8 +1025,7 @@
 "aGO" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1156,6 +1124,9 @@
 "aJp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame3/central)
 "aJG" = (
@@ -1222,6 +1193,23 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/science)
+"aLh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hor_window";
+	name = "privacy shutter"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/ship/preopen{
+	dir = 4;
+	id = "biohazard";
+	name = "Biohazard"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "aLA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -1242,9 +1230,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "aMd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -1264,13 +1250,10 @@
 "aMA" = (
 /obj/structure/sign/directions/plaque/lift{
 	dir = 8;
-	icon_state = "minskydirection_lift";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "aML" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -1325,6 +1308,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/rack,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -1416,6 +1401,17 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/tcommsat/server)
+"aRK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck1/starboard)
 "aRM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1451,9 +1447,7 @@
 	dir = 9
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "aSQ" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow{
@@ -1470,9 +1464,7 @@
 	dir = 1
 	},
 /turf/open/floor/engine,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "aTc" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 4
@@ -1492,7 +1484,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = 26
 	},
 /obj/item/clothing/suit/radiation,
@@ -1514,13 +1505,10 @@
 /area/engine/atmos)
 "aTV" = (
 /obj/effect/turf_decal/stripes/end{
-	dir = 8;
-	icon_state = "warn_end"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "aTZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1573,7 +1561,6 @@
 	name = "Primary Hangar Bay";
 	req_one_access_txt = "3;69"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile/dark,
@@ -1591,7 +1578,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
-	sortType = 7
+	sortType = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame2/central)
@@ -1621,8 +1608,7 @@
 "aWS" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
@@ -1679,8 +1665,7 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "aYb" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -1711,6 +1696,9 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "aZs" = (
@@ -1779,16 +1767,14 @@
 /area/engine/atmos)
 "baa" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/techmaint,
 /area/science/lab)
 "bak" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
@@ -1798,17 +1784,23 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "baO" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/plasteel/grid/lino,
-/area/ai_monitored/nuke_storage)
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "bbp" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -1818,9 +1810,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "bbv" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -1836,8 +1826,7 @@
 /obj/structure/chair/stool,
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/ship,
 /area/security/prison)
@@ -1854,16 +1843,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8;
-	icon_state = "warningline"
+	dir = 8
 	},
 /obj/structure/rack,
 /obj/item/clothing/head/welding,
 /obj/item/clothing/head/welding,
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "bcs" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer3{
@@ -1873,9 +1859,7 @@
 /area/space/nearstation)
 "bct" = (
 /turf/closed/wall/r_wall,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "bcv" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -1918,6 +1902,9 @@
 /area/security/prison)
 "beq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -1955,15 +1942,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "beQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet/red,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "bfO" = (
 /obj/machinery/light_switch/east,
 /obj/structure/cable{
@@ -1976,18 +1959,14 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "bfS" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame2/central)
@@ -2011,9 +1990,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "bgc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2073,15 +2050,11 @@
 	name = "Air Control Left";
 	req_one_access_txt = "19;69"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 6
-	},
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "biY" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -2199,9 +2172,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "boc" = (
 /obj/machinery/button/door{
 	id = "fighterpod_airlock";
@@ -2217,9 +2188,7 @@
 	},
 /obj/machinery/light/runway/delay4,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "bos" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -2252,9 +2221,7 @@
 /obj/item/clothing/neck/squad,
 /obj/item/clothing/neck/squad,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "bpa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -2326,11 +2293,10 @@
 /turf/open/floor/plasteel/ship,
 /area/crew_quarters/heads/chief)
 "bqQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/carpet/red,
-/area/security/detectives_office)
+/obj/item/fighter_component/apu,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/monotile,
+/area/nsv/hanger/notkmcstupidhanger)
 "brd" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -2361,14 +2327,20 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/bridge)
+"brT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "2-5"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/bridge)
 "brW" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/on/layer3{
-	dir = 8;
-	filter_type = "n2"
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
@@ -2383,9 +2355,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "bso" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2453,12 +2423,10 @@
 /area/science/xenobiology)
 "btA" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/status_display/ai/north,
 /turf/open/floor/plasteel/grid/mono,
@@ -2466,9 +2434,7 @@
 "btR" = (
 /obj/vehicle/sealed/car/realistic/fighter_tug,
 /turf/open/floor/plasteel/elevatorshaft,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "btX" = (
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 4;
@@ -2485,9 +2451,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "buQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -2561,8 +2525,7 @@
 "bxD" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -2658,8 +2621,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grid/techfloor,
 /area/tcommsat/server)
@@ -2675,9 +2637,6 @@
 /turf/open/floor/monotile,
 /area/shuttle/turbolift/secondary)
 "bAs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
@@ -2698,9 +2657,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "bBf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -2708,19 +2665,18 @@
 	c_tag = "CIC - Fore";
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "bBh" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2859,9 +2815,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "bEY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -2878,10 +2832,6 @@
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"bFG" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "bFT" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -2898,8 +2848,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2918,8 +2867,7 @@
 /area/security/prison)
 "bGR" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/science/lab)
@@ -2951,12 +2899,10 @@
 "bHt" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -2975,8 +2921,7 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "bIf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/carpet/red,
 /area/security/checkpoint/science)
@@ -2985,7 +2930,7 @@
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "bJo" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "bJp" = (
@@ -3040,9 +2985,7 @@
 /obj/structure/rack,
 /obj/item/fighter_component/secondary/heavy/torpedo_rack/t1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "bLs" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment{
@@ -3051,21 +2994,18 @@
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
 "bLB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/shutters/ship/preopen{
-	dir = 4;
-	id = "hor_window";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/science)
-"bLR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck1/port)
+"bLR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
@@ -3099,9 +3039,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "bNB" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 6
@@ -3127,9 +3065,7 @@
 /obj/structure/bed/dogbed/ian,
 /mob/living/simple_animal/pet/dog/corgi/Ian,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "bNU" = (
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/carpet/black,
@@ -3137,9 +3073,7 @@
 "bOa" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "bOd" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer1{
 	dir = 8
@@ -3205,9 +3139,7 @@
 	dir = 10
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "bPk" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -3228,8 +3160,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
@@ -3238,9 +3169,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "bQf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/ship/preopen{
@@ -3262,9 +3191,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "bQH" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
@@ -3293,10 +3220,11 @@
 	name = "Bridge RC";
 	pixel_x = 32
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "bRj" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input,
 /turf/open/floor/engine/plasma,
@@ -3397,14 +3325,20 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "bVu" = (
 /obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck1/starboard)
+/area/maintenance/nsv/deck1/port)
 "bVD" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -3442,9 +3376,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "bWy" = (
 /obj/structure/cable{
 	icon_state = "1-6"
@@ -3472,8 +3404,8 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -3504,9 +3436,7 @@
 	},
 /obj/structure/fighter_launcher/launch_only,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "bYm" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -3590,6 +3520,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "cbK" = (
@@ -3597,9 +3528,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "cbN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -3613,9 +3542,7 @@
 	id = "launch2"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ccF" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3642,6 +3569,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "cdd" = (
@@ -3656,6 +3584,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
+"cdB" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "cdF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3666,7 +3603,7 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
 "cdK" = (
-/obj/machinery/space_heater,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "cdO" = (
@@ -3690,9 +3627,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grid/techfloor,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "cev" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -3704,8 +3639,7 @@
 /area/gateway)
 "ceA" = (
 /obj/effect/turf_decal/stripes/end{
-	dir = 4;
-	icon_state = "warn_end"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger)
@@ -3718,9 +3652,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/overmap/fighter/light/prebuilt,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "cfB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
@@ -3741,6 +3673,9 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering)
 "cfS" = (
@@ -3751,9 +3686,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "cgr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3780,6 +3713,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame2/central)
 "cgO" = (
@@ -3791,9 +3725,7 @@
 	pixel_y = -26
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "cgR" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -3874,8 +3806,7 @@
 "ciU" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -3892,9 +3823,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
@@ -3903,9 +3831,7 @@
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "ckl" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -3917,12 +3843,10 @@
 "ckE" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -3937,9 +3861,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "clA" = (
 /obj/machinery/button/door{
 	id = "fighterpod_airlock";
@@ -3951,9 +3873,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "clF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4008,9 +3928,7 @@
 "coX" = (
 /obj/structure/sign/ship/shock,
 /turf/closed/wall/steel,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "cpa" = (
 /obj/machinery/light{
 	dir = 8
@@ -4029,9 +3947,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grid/techfloor,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "cph" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/yellow{
@@ -4066,7 +3982,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_x = 26
 	},
 /turf/open/floor/monotile,
@@ -4084,12 +3999,10 @@
 /area/engine/atmos)
 "cqD" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4118,9 +4031,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ctH" = (
 /obj/structure/table/reinforced,
 /obj/item/phone,
@@ -4166,10 +4077,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame1/central)
 "cwi" = (
@@ -4178,13 +4089,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "cwl" = (
 /obj/structure/cable{
 	icon_state = "2-9"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4212,9 +4122,7 @@
 "cxj" = (
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "cxk" = (
 /obj/effect/turf_decal/tile/ship/neutral{
 	dir = 4
@@ -4238,6 +4146,9 @@
 	dir = 8
 	},
 /obj/machinery/computer/ship/viewscreen,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering)
 "cxy" = (
@@ -4296,13 +4207,10 @@
 	icon_state = "5-10"
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "cyP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
@@ -4363,26 +4271,21 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "cAt" = (
 /turf/closed/wall/steel,
 /area/shuttle/turbolift/tertiary)
 "cAz" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame1/central)
 "cAU" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet/red,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "cBa" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/monotile,
@@ -4422,6 +4325,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/main)
 "cCc" = (
@@ -4436,7 +4342,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "Atmospherics Mix -> Stormdrive"
+	name = "Atmospherics Mix to Stormdrive"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -4450,11 +4356,16 @@
 /turf/closed/wall/r_wall,
 /area/nsv/briefingroom)
 "cCW" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck1/port)
 "cDd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -4583,15 +4494,12 @@
 /area/engine/atmospherics_engine)
 "cHu" = (
 /obj/machinery/computer/ship/dradis/minor/console{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "cHV" = (
 /obj/structure/hull_plate,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -4653,6 +4561,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
+"cJA" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "cJO" = (
 /obj/machinery/gateway{
 	dir = 6
@@ -4730,9 +4649,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"cMR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/monotile,
+/area/nsv/briefingroom)
 "cMS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4821,17 +4751,13 @@
 	name = "WARNING: WEAR HEARING PROTECTION"
 	},
 /turf/closed/wall/r_wall,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "cQN" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -4843,8 +4769,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering)
@@ -4884,17 +4809,13 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "cSP" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8;
-	icon_state = "warningline"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "cSV" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4937,9 +4858,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "cUm" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -4996,6 +4915,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
 "cVw" = (
@@ -5004,11 +4924,9 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "cVD" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "cWx" = (
 /obj/machinery/door/airlock/ship/security/glass{
 	id_tag = "pw_fd_inner";
@@ -5016,8 +4934,7 @@
 	req_one_access_txt = "63"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -5084,14 +5001,12 @@
 	},
 /obj/machinery/door/airlock/ship/engineering{
 	dir = 8;
-	icon_state = "closed";
 	name = "Reactor Core";
 	req_one_access_txt = "32;11"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-5"
@@ -5119,9 +5034,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "cYv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5131,11 +5044,13 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "cYY" = (
@@ -5161,9 +5076,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "cZp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/preopen{
@@ -5176,15 +5089,10 @@
 /area/science/xenobiology)
 "cZv" = (
 /obj/effect/turf_decal/box,
-/obj/structure/closet/secure_closet/engineering_welding{
-	anchored = 1;
-	name = "munitions welding supplies locker";
-	req_access = null;
-	req_one_access_txt = "69"
-	},
 /obj/machinery/status_display/evac/north{
 	pixel_y = 26
 	},
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/grid/steel,
 /area/nsv/hanger/notkmcstupidhanger)
 "cZN" = (
@@ -5212,12 +5120,10 @@
 "dbP" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/mono,
@@ -5302,7 +5208,6 @@
 /obj/structure/grille,
 /obj/structure/sign/ship/securearea{
 	dir = 8;
-	icon_state = "securearea";
 	pixel_x = 32
 	},
 /turf/open/floor/plating,
@@ -5340,7 +5245,6 @@
 /area/gateway)
 "dfL" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/space)
 "dhK" = (
@@ -5358,9 +5262,7 @@
 	id = "launch2"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dhS" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
@@ -5457,8 +5359,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5494,28 +5395,32 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
+"dmE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck1/starboard)
 "dmS" = (
 /obj/machinery/computer/security/console{
 	dir = 5;
-	icon_screen = null;
-	icon_state = "computer_end"
+	icon_screen = null
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "dnh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
@@ -5558,8 +5463,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -5570,9 +5474,7 @@
 "dor" = (
 /obj/item/fighter_component/avionics,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "doD" = (
 /obj/structure/cable{
 	icon_state = "1-10"
@@ -5645,14 +5547,17 @@
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "dqw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/holopad,
 /turf/open/floor/monotile/dark,
 /area/storage/tech)
+"dqC" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dqF" = (
 /obj/machinery/ai_slipper,
 /turf/open/floor/circuit,
@@ -5672,9 +5577,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dse" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -5732,21 +5635,15 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dtS" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/plasteel/grid/mono,
-/area/hallway/nsv/deck1/frame3/central)
+/area/maintenance/nsv/deck1/port)
 "dtZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -5837,6 +5734,7 @@
 "dvw" = (
 /obj/item/fighter_component/countermeasure_dispenser/t1,
 /obj/item/fighter_component/targeting_sensor/light/t1,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/monotile,
 /area/nsv/hanger/notkmcstupidhanger)
 "dvz" = (
@@ -5860,8 +5758,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating{
@@ -5874,9 +5771,7 @@
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dxg" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w/layer1,
 /turf/open/floor/engine/airless,
@@ -5905,9 +5800,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/grid/techfloor,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "dyc" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -5928,9 +5821,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dzk" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
@@ -5983,18 +5874,21 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dAw" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/ship{
 	id = "launch1"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"dAx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/port)
 "dBg" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -6046,9 +5940,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dCK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6073,9 +5965,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "dDg" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -6150,6 +6040,10 @@
 /obj/machinery/vending/assist,
 /turf/open/floor/monotile/dark,
 /area/storage/tech)
+"dFG" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile,
+/area/crew_quarters/heads/captain)
 "dFO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/techmaint,
@@ -6162,9 +6056,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dGf" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/red,
@@ -6180,9 +6072,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dGW" = (
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/notkmcstupidhanger)
@@ -6209,13 +6099,10 @@
 /area/science/mixing)
 "dHM" = (
 /obj/machinery/computer/cargo/request{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "dHT" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
@@ -6234,9 +6121,25 @@
 "dIn" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"dIA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/engine/engineering)
 "dIB" = (
 /obj/item/ship_weapon/ammunition/torpedo/hull_shredder,
 /obj/item/ship_weapon/ammunition/torpedo/hull_shredder,
@@ -6256,8 +6159,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/carpet/green,
 /area/tcommsat/server)
@@ -6269,8 +6171,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
@@ -6346,9 +6247,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dLd" = (
 /obj/structure/table/wood,
 /obj/item/phone,
@@ -6384,17 +6283,13 @@
 "dLW" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "dMw" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "dMU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
@@ -6417,16 +6312,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "dNV" = (
 /turf/closed/wall/steel,
 /area/engine/engine_smes)
@@ -6443,8 +6335,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
@@ -6459,15 +6350,11 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "dPg" = (
 /obj/machinery/computer/rdconsole/robotics{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
 "dPl" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -6515,7 +6402,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump/layer1{
-	name = "Plasma -> Incinerator Engine"
+	name = "Plasma to Incinerator Engine"
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -6570,20 +6457,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger)
-"dRH" = (
-/turf/closed/wall/r_wall,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
 "dSE" = (
 /obj/structure/sign/ship/securearea/alt{
-	dir = 8;
-	icon_state = "securearea2"
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "dSH" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
 /turf/open/floor/monotile/dark,
@@ -6601,14 +6480,6 @@
 /obj/structure/overmap/fighter/light/prebuilt/flight_leader,
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger)
-"dTs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
 "dTA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6618,6 +6489,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -6633,6 +6507,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
+"dUx" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "dUC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/structure/cable/yellow{
@@ -6678,6 +6557,9 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/west,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/nsv/hanger/notkmcstupidhanger)
 "dWM" = (
@@ -6739,9 +6621,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "dXO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -6756,9 +6636,7 @@
 "dYR" = (
 /obj/machinery/light,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "dYU" = (
 /obj/structure/sign/ship/nosmoking,
 /turf/closed/wall/steel,
@@ -6854,9 +6732,7 @@
 	},
 /obj/structure/closet,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "ecB" = (
 /obj/structure/closet/radiation,
 /obj/item/shovel,
@@ -6940,9 +6816,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "egl" = (
 /obj/machinery/computer/camera_advanced/xenobio,
 /turf/open/floor/monotile/dark,
@@ -7009,12 +6883,10 @@
 "eix" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Long Term Confinement";
@@ -7034,6 +6906,10 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering)
+"ekl" = (
+/obj/effect/turf_decal/tile/ship/green,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/frame1/central)
 "ekG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
@@ -7084,9 +6960,7 @@
 /obj/machinery/light,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "elZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -7133,6 +7007,24 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer1,
 /turf/open/floor/engine/airless,
 /area/engine/atmospherics_engine)
+"enf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sink{
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "enw" = (
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 4;
@@ -7150,9 +7042,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "enH" = (
 /obj/machinery/light{
 	dir = 8
@@ -7165,12 +7055,10 @@
 /area/tcommsat/server)
 "eoh" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/camera/autoname{
@@ -7205,9 +7093,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "eqN" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet/red,
@@ -7246,9 +7132,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "erF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -7301,8 +7185,7 @@
 "etw" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -7332,10 +7215,9 @@
 	name = "briefing room chair"
 	},
 /obj/machinery/light,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "eul" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -7347,9 +7229,6 @@
 /turf/open/floor/monotile,
 /area/nsv/hanger/notkmcstupidhanger)
 "euA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -7395,9 +7274,7 @@
 	pixel_y = -96
 	},
 /turf/open/floor/engine,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "ewV" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -7419,10 +7296,13 @@
 "eyW" = (
 /turf/closed/wall/r_wall,
 /area/security/main)
+"ezJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile,
+/area/maintenance/nsv/deck1/starboard)
 "eAj" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile,
@@ -7433,25 +7313,11 @@
 /turf/open/floor/monotile,
 /area/science/mixing)
 "eAB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 29;
-	pixel_y = -28
+/obj/machinery/space_heater,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/ship,
-/area/security/prison)
+/area/maintenance/nsv/deck1/port)
 "eAG" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/cryopod{
@@ -7468,12 +7334,10 @@
 /area/bridge/meeting_room)
 "eBb" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -7488,9 +7352,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "eCt" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -7527,13 +7389,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "eDY" = (
 /obj/machinery/computer/console_placholder{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -7542,9 +7401,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "eEw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -7590,7 +7447,6 @@
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "eGd" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/bot,
 /obj/machinery/recharge_station,
 /turf/open/floor/monotile/dark,
@@ -7610,6 +7466,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -7628,9 +7487,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "eHO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7640,10 +7497,9 @@
 	dir = 8
 	},
 /obj/machinery/holopad,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/red,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "eHS" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
 	dir = 10
@@ -7669,9 +7525,7 @@
 /obj/machinery/suit_storage_unit/pilot,
 /obj/machinery/light,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "eIo" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8;
@@ -7697,9 +7551,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "eJu" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -7719,9 +7571,7 @@
 	},
 /obj/machinery/light/runway/delay2,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "eJY" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/monotile/dark,
@@ -7768,8 +7618,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -7855,8 +7704,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint)
@@ -7901,8 +7749,7 @@
 "eOS" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -7912,8 +7759,7 @@
 "ePp" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -8047,8 +7893,8 @@
 /turf/closed/wall/steel,
 /area/shuttle/turbolift)
 "eUb" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump/layer3{
+	name = "O2 to Mix"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -8085,9 +7931,7 @@
 /area/engine/engineering)
 "eUW" = (
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "eVj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8096,21 +7940,17 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/security/processing)
 "eVY" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "eWq" = (
 /obj/machinery/ai_slipper,
 /turf/open/floor/plasteel/grid/techfloor,
@@ -8256,9 +8096,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "fco" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -8348,9 +8186,7 @@
 	},
 /obj/machinery/light/runway,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ffk" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/box/white,
@@ -8494,9 +8330,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "fjp" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/computer/ship/viewscreen,
@@ -8543,9 +8377,7 @@
 	},
 /obj/machinery/light/runway/delay4,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "fjZ" = (
 /turf/open/openspace,
 /area/hallway/nsv/deck1/frame1/central)
@@ -8554,9 +8386,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "fkp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -8600,12 +8430,10 @@
 "fkO" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8617,9 +8445,14 @@
 "flg" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
+"fls" = (
+/obj/effect/turf_decal/tile/ship/half/green,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/frame3/central)
 "flP" = (
 /obj/structure/hull_plate/end{
 	dir = 1
@@ -8675,9 +8508,7 @@
 	id = "launch1"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "foM" = (
 /obj/machinery/light{
 	dir = 8
@@ -8702,12 +8533,18 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/nsv/bridge)
+"fpj" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/carpet/orange,
+/area/engine/atmos)
 "fqg" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "fql" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -8783,16 +8620,15 @@
 /area/crew_quarters/heads/chief)
 "fsr" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/monotile,
 /area/engine/engineering)
 "fsF" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -8869,7 +8705,6 @@
 /area/tcommsat/server)
 "fvB" = (
 /obj/effect/turf_decal/box,
-/obj/structure/closet/firecloset,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
@@ -8883,6 +8718,7 @@
 	cell_type = /obj/item/stock_parts/cell/upgraded/plus;
 	pixel_y = 24
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/grid/steel,
 /area/nsv/hanger/notkmcstupidhanger)
 "fwf" = (
@@ -8898,9 +8734,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "fwk" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/poddoor/ship{
@@ -8910,9 +8744,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "fwM" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -9062,6 +8894,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "fBP" = (
@@ -9093,6 +8926,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/main)
 "fCt" = (
@@ -9107,10 +8943,10 @@
 /area/crew_quarters/heads/captain)
 "fCD" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/camera/autoname,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
 "fCF" = (
@@ -9238,15 +9074,29 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "fJD" = (
 /obj/item/fighter_component/countermeasure_dispenser/t1,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"fJY" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_x = -2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/maintenance/nsv/deck1/starboard)
 "fKz" = (
 /obj/machinery/computer/operating{
 	dir = 4
@@ -9286,9 +9136,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "fLD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -9436,6 +9284,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
+"fPP" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 8
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/frame3/central)
 "fQi" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/mineral/plasma,
@@ -9467,9 +9322,7 @@
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "fRg" = (
 /turf/open/floor/fakespace,
 /area/maintenance/nsv/bridge)
@@ -9499,9 +9352,6 @@
 	req_access_txt = "53"
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -9512,8 +9362,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -9678,6 +9527,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/storage)
 "fXX" = (
@@ -9691,9 +9543,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "fYb" = (
 /obj/structure/table/glass,
 /obj/item/folder/blue,
@@ -9725,9 +9575,7 @@
 /area/engine/atmos)
 "fZT" = (
 /turf/open/floor/plasteel/elevatorshaft,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "fZW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -9736,9 +9584,7 @@
 	id = "launch2"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "gaa" = (
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
@@ -9951,13 +9797,10 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "gfG" = (
 /obj/effect/turf_decal/tile/ship/blue{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -10016,9 +9859,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	sortType = 12
 	},
@@ -10037,10 +9877,8 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
 /area/science)
 "ghP" = (
@@ -10049,13 +9887,11 @@
 	req_one_access_txt = "16"
 	},
 /obj/machinery/door/poddoor/ship/preopen{
-	dir = 2;
 	id = "inneraicore"
 	},
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -10081,20 +9917,16 @@
 /area/engine/storage)
 "ghT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ghY" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -10108,9 +9940,7 @@
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "gkf" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
@@ -10144,6 +9974,15 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/ai_monitored/turret_protected/AIsatextAP)
+"gkN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "detective_shutters";
+	name = "detective's office shutters"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "gkR" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -10206,8 +10045,7 @@
 "gmz" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/ship/security/glass{
@@ -10226,10 +10064,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/security/checkpoint)
+"gmC" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/nsv/bridge)
 "gmO" = (
 /obj/effect/turf_decal/tile/ship/blue{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/item/ship_weapon/ammunition/torpedo/probe,
 /obj/machinery/computer/ship/viewscreen,
@@ -10240,19 +10083,16 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/science/robotics/mechbay)
 "gnp" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10310,9 +10150,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "goq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10418,8 +10256,7 @@
 "grI" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -10435,28 +10272,22 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/fighter_component/underconstruction_fighter/heavy_fighter_frame,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "gsm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "gsu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "O2 -> Mix"
-	},
-/turf/open/floor/monotile/dark,
-/area/engine/atmos)
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/port)
 "gtz" = (
 /obj/effect/turf_decal/tile/ship/blue{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -10564,6 +10395,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/prison)
 "gxi" = (
@@ -10574,15 +10408,12 @@
 /turf/open/floor/monotile,
 /area/science/xenobiology)
 "gxu" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 6
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
@@ -10596,6 +10427,10 @@
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank,
 /obj/effect/turf_decal/bot{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/trinary/filter/flipped/on/layer3{
+	dir = 8;
+	filter_type = "n2"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -10636,9 +10471,7 @@
 	id = "launch2"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "gyP" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -10701,9 +10534,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "gAp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -10718,9 +10549,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "gAM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4
@@ -10822,12 +10651,10 @@
 "gEp" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -10838,12 +10665,10 @@
 /area/hallway/nsv/deck1/frame1/central)
 "gFC" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame2/central)
@@ -10862,6 +10687,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "gGl" = (
@@ -10870,7 +10696,6 @@
 	},
 /area/maintenance/nsv/bridge)
 "gGI" = (
-/obj/structure/cable,
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen,
 /obj/item/tank/internals/oxygen,
@@ -10921,14 +10746,11 @@
 "gIB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "gIQ" = (
 /turf/closed/wall/r_wall,
 /area/security/processing)
@@ -11003,9 +10825,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "gKP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -11160,6 +10980,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/main)
 "gQu" = (
@@ -11260,12 +11083,9 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/nsv/hanger/notkmcstupidhanger)
 "gTp" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/components/binary/pump/layer1{
-	name = "N2 -> Stormdrive Flavouriser"
+	name = "N2 to Stormdrive Flavouriser"
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/monotile,
@@ -11293,6 +11113,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/monotile,
 /area/gateway)
 "gUD" = (
@@ -11303,9 +11124,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "gVc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11348,9 +11167,19 @@
 /obj/structure/filingcabinet,
 /obj/machinery/light,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
+"gXe" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-10"
+	},
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/bridge)
 "gXl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
@@ -11368,8 +11197,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
@@ -11389,7 +11217,7 @@
 	req_one_access_txt = "24"
 	},
 /turf/open/floor/engine/airless,
-/area/engine/atmos)
+/area/space)
 "gYj" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -11408,9 +11236,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "gYu" = (
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/copper{
@@ -11447,9 +11273,7 @@
 /area/engine/atmos)
 "gZs" = (
 /turf/closed/wall/steel,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "gZv" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -11472,6 +11296,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/techmaint,
 /area/engine/storage)
 "haR" = (
@@ -11481,8 +11306,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
+"hcy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck1/starboard)
 "hcC" = (
 /turf/open/floor/monotile,
 /area/gateway)
@@ -11498,19 +11337,23 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "hdm" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"hdu" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/port)
 "hdz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	sortType = 14
@@ -11565,9 +11408,7 @@
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "hek" = (
 /obj/machinery/computer/monitor{
 	dir = 8
@@ -11582,9 +11423,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "hep" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #6";
@@ -11595,12 +11434,10 @@
 /area/science/xenobiology)
 "heu" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame1/central)
@@ -11613,9 +11450,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "heJ" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -11664,9 +11499,6 @@
 "hfV" = (
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -11737,13 +11569,8 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "hkB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/closed/wall/r_wall,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "hkK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -11782,8 +11609,7 @@
 /area/security/prison)
 "hlt" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 4
@@ -11804,8 +11630,7 @@
 /area/security/main)
 "hmg" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame1/central)
@@ -11822,9 +11647,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "hng" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/guncase/shotgun{
@@ -11905,9 +11728,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "hpA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11944,9 +11765,18 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"hqA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/frame1/central)
 "hqW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -11976,9 +11806,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "hrf" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -11998,9 +11826,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "hrn" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -12022,6 +11848,10 @@
 /obj/machinery/computer/atmos_control/tank/oxygen_tank,
 /obj/effect/turf_decal/bot{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -12073,9 +11903,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "htu" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
@@ -12084,8 +11912,7 @@
 /area/engine/atmos)
 "htM" = (
 /obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	name = "manual inlet valve"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing)
@@ -12205,9 +12032,11 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
+"hwW" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/monotile,
+/area/maintenance/nsv/bridge)
 "hwX" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o,
@@ -12241,15 +12070,11 @@
 	},
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "hxm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plating,
-/area/maintenance/nsv/bridge)
+/area/maintenance/nsv/deck1/port)
 "hxw" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 4;
@@ -12273,9 +12098,7 @@
 	dir = 6
 	},
 /turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "hxI" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -12292,6 +12115,16 @@
 	},
 /turf/open/floor/monotile,
 /area/science/xenobiology)
+"hxJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "captainofficeshutters"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/captain)
 "hyF" = (
 /obj/structure/chair/stool/bar,
 /obj/machinery/airalarm{
@@ -12315,6 +12148,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
 "hAG" = (
@@ -12323,7 +12157,6 @@
 	},
 /obj/machinery/holopad,
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = -26
 	},
 /turf/open/floor/carpet/ship,
@@ -12342,22 +12175,17 @@
 /turf/open/floor/monotile/light,
 /area/security/processing)
 "hBE" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine,
 /area/engine/atmos)
 "hCc" = (
 /obj/effect/turf_decal/tile/ship/red,
 /obj/effect/turf_decal/tile/ship/red{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/red{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12390,9 +12218,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "hCv" = (
 /obj/machinery/door/window/brigdoor/northleft{
 	dir = 4;
@@ -12424,9 +12250,7 @@
 "hDq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "hDJ" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -12436,12 +12260,10 @@
 /area/crew_quarters/heads/chief)
 "hEr" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -12476,9 +12298,7 @@
 "hEU" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "hFe" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -12521,6 +12341,12 @@
 /obj/machinery/light,
 /turf/open/floor/monotile,
 /area/engine/break_room)
+"hGh" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/frame1/central)
 "hGm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -12546,10 +12372,8 @@
 /area/hallway/nsv/deck1/frame3/central)
 "hGt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/ship/engineering/glass{
@@ -12617,9 +12441,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "hJp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile/dark,
@@ -12629,8 +12451,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -12642,6 +12463,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
+"hKp" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/nsv/bridge)
 "hKM" = (
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
@@ -12669,8 +12496,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering)
@@ -12688,18 +12514,21 @@
 	},
 /turf/open/floor/monotile,
 /area/science/mixing)
+"hMv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/crew_quarters/heads/captain)
 "hMM" = (
 /obj/structure/sign/ship/shock{
 	dir = 4
 	},
 /turf/closed/wall/steel,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "hMO" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/grid/mono,
@@ -12720,9 +12549,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "hNJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12768,9 +12595,7 @@
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "hPN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -12863,8 +12688,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8;
-	icon_state = "warningline"
+	dir = 8
 	},
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/silver{
@@ -12873,9 +12697,7 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/mineral/titanium/fifty,
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "hTL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -12885,12 +12707,10 @@
 /area/maintenance/nsv/deck1/starboard)
 "hTZ" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/grid/mono,
@@ -12898,6 +12718,14 @@
 "hUf" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/atmos)
+"hUk" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Starboard";
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
@@ -12947,6 +12775,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "hVr" = (
@@ -12990,9 +12821,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "hWk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/effect/turf_decal/tile/purple,
@@ -13078,15 +12907,9 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "hZW" = (
-/obj/machinery/door/firedoor,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "detective_shutters";
-	name = "detective's office shutters"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/security/detectives_office)
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "hZZ" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -13101,6 +12924,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/monotile,
@@ -13120,17 +12946,13 @@
 /obj/item/squad_pager/all_channels,
 /obj/item/clothing/neck/squad,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "ibl" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/camera/autoname,
@@ -13228,20 +13050,25 @@
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/captain)
 "ihh" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 6
+	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ihk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/poddoor/ship{
 	id = "launch1"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"iht" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/nsv/deck1/starboard)
 "ihB" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -13262,12 +13089,10 @@
 /area/maintenance/nsv/bridge)
 "iiD" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/status_display/ai/north,
 /turf/open/floor/plasteel/grid/mono,
@@ -13281,6 +13106,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
@@ -13321,8 +13149,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -13395,12 +13222,14 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Hallway - Aft"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering)
 "ioI" = (
 /obj/effect/turf_decal/tile/ship/blue{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -13436,9 +13265,7 @@
 	id = "launch1"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ipR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating{
@@ -13572,8 +13399,7 @@
 "itC" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
@@ -13585,9 +13411,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/holopad,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "iud" = (
 /obj/machinery/door/airlock/ship/hatch{
 	name = "Network Administration";
@@ -13603,8 +13427,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -13686,16 +13509,15 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame1/central)
 "iyv" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/camera/autoname{
@@ -13728,12 +13550,10 @@
 "izc" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/structure/sign/ship/nosmoking{
 	dir = 8;
-	icon_state = "nosmoking";
 	pixel_x = 32
 	},
 /obj/machinery/camera/autoname{
@@ -13792,9 +13612,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "iAA" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -13820,14 +13638,13 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "iBx" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "iCl" = (
@@ -13857,9 +13674,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "iCO" = (
 /obj/machinery/light/small,
 /obj/item/storage/box/donkpockets,
@@ -13938,15 +13753,13 @@
 /turf/open/floor/monotile/dark,
 /area/security/main)
 "iEc" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/structure/cable{
-	icon_state = "1-6"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/nsv/bridge)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame1/central)
 "iEd" = (
 /obj/effect/turf_decal/tile/ship/half/blue{
 	dir = 1
@@ -13964,8 +13777,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/floor/plating{
@@ -13986,8 +13798,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/security/checkpoint)
@@ -14016,9 +13827,7 @@
 	dir = 5
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "iGD" = (
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/monotile/dark/airless{
@@ -14069,21 +13878,17 @@
 /area/engine/atmos)
 "iIq" = (
 /obj/machinery/camera/autoname{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/open/floor/plasteel/elevatorshaft,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "iIM" = (
 /obj/structure/sign/ship/deck,
 /turf/closed/wall/steel,
 /area/hallway/nsv/deck1/frame1/central)
 "iIX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/security/checkpoint)
@@ -14107,6 +13912,11 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
+"iKn" = (
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/structure/closet/emcloset,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/frame3/central)
 "iKo" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
@@ -14117,9 +13927,7 @@
 "iKr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "iKt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -14170,12 +13978,15 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
+"iLy" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating,
+/area/maintenance/nsv/bridge)
 "iLz" = (
 /obj/machinery/atmospherics/pipe/simple/brown/visible/layer3,
 /turf/open/floor/plating,
@@ -14184,6 +13995,24 @@
 /obj/machinery/airalarm/directional/east,
 /turf/template_noop,
 /area/maintenance/nsv/deck1/starboard)
+"iMI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/frame3/central)
 "iNo" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -14203,9 +14032,7 @@
 "iNY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet/red,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "iOL" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -14248,9 +14075,36 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "iPy" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/plating,
+/obj/structure/closet{
+	anchored = 1;
+	name = "squad surplus equipment"
+	},
+/obj/item/squad_pager,
+/obj/item/squad_pager,
+/obj/item/squad_pager,
+/obj/item/squad_pager,
+/obj/item/squad_pager,
+/obj/item/clothing/neck/squad,
+/obj/item/clothing/neck/squad,
+/obj/item/clothing/neck/squad,
+/obj/item/clothing/neck/squad,
+/obj/item/clothing/neck/squad,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grid/mono,
 /area/maintenance/nsv/deck1/starboard)
 "iPF" = (
 /obj/machinery/telecomms/server/presets/science,
@@ -14277,8 +14131,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -14311,9 +14164,7 @@
 	dir = 5
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "iSo" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -14349,23 +14200,17 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "iSJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "iSS" = (
 /obj/structure/sign/ship/securearea{
-	dir = 8;
-	icon_state = "securearea"
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -14386,28 +14231,31 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "iUX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "iVe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/storage)
+"iVq" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/frame3/central)
 "iWT" = (
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -14501,9 +14349,7 @@
 	dir = 4
 	},
 /turf/closed/wall/steel,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "iZd" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
@@ -14527,6 +14373,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -14541,9 +14388,7 @@
 	},
 /obj/machinery/light/runway/delay5,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "iZB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -14560,8 +14405,7 @@
 "jam" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
@@ -14574,9 +14418,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jaH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8
@@ -14599,12 +14441,21 @@
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
+"jbU" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "jcI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "jdh" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -14701,9 +14552,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -14723,9 +14571,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jid" = (
 /obj/machinery/atmospherics/components/binary/circulator,
 /obj/structure/cable/yellow{
@@ -14738,12 +14584,10 @@
 /area/science)
 "jis" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -14766,26 +14610,22 @@
 /area/nsv/briefingroom)
 "jiN" = (
 /obj/machinery/computer/console_placholder{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "jiR" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/binary/pump/on/layer1{
-	name = "Air -> Distro"
+	name = "Air to Distro"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -14799,6 +14639,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "jjK" = (
@@ -14809,6 +14650,11 @@
 /obj/structure/closet/secure_closet/security/science,
 /turf/open/floor/monotile,
 /area/security/checkpoint/science)
+"jkL" = (
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/security/prison)
 "jkS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -14846,6 +14692,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
 "jls" = (
@@ -14854,9 +14701,7 @@
 	req_one_access_txt = "3;69"
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jlD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -14873,19 +14718,18 @@
 	dir = 6
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "jmj" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "jmq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
@@ -14926,24 +14770,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "jnJ" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grid/lino,
 /area/security/detectives_office)
 "jnM" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -14954,9 +14798,7 @@
 "jog" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jpz" = (
 /obj/machinery/power/solar,
 /obj/structure/cable/yellow{
@@ -14994,6 +14836,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
+"jqF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/port)
 "jrc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -15018,9 +14868,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jsb" = (
 /obj/machinery/computer/ship/helm/console,
 /obj/effect/turf_decal/stripes/line{
@@ -15033,9 +14881,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "jsc" = (
 /obj/machinery/door/airlock/ship{
 	name = "Nanite Laboratory";
@@ -15047,6 +14893,9 @@
 "jso" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
@@ -15106,9 +14955,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jub" = (
 /turf/closed/wall/r_wall,
 /area/shuttle/turbolift/quaternary)
@@ -15120,12 +14967,10 @@
 /area/science/xenobiology)
 "jvh" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -15198,14 +15043,11 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/structure/closet/secure_closet/bridge,
 /turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "jwo" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -15230,9 +15072,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jxi" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
@@ -15260,9 +15100,7 @@
 /area/engine/engineering)
 "jxQ" = (
 /turf/open/floor/engine,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "jxZ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
 /obj/structure/lattice,
@@ -15292,9 +15130,7 @@
 	pixel_x = -23
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jyG" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 26
@@ -15303,6 +15139,7 @@
 /area/security/prison)
 "jyP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "jyZ" = (
@@ -15394,9 +15231,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "jCa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -15437,8 +15272,7 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "jDs" = (
 /obj/structure/sign/ship/securearea{
-	dir = 4;
-	icon_state = "securearea"
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/security/processing)
@@ -15463,9 +15297,6 @@
 /area/science/mixing)
 "jEl" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/preset/toxins{
-	dir = 1
-	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "jEO" = (
@@ -15477,9 +15308,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "jEQ" = (
 /obj/effect/turf_decal/tile/ship/half/red,
 /obj/structure/cable{
@@ -15493,6 +15322,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/security/prison)
@@ -15514,8 +15346,7 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -15523,16 +15354,16 @@
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
 "jFk" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
+	dir = 6
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
@@ -15630,9 +15461,7 @@
 "jJo" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jJr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating{
@@ -15646,9 +15475,6 @@
 /obj/machinery/door/airlock/ship{
 	name = "Research and Development Lab";
 	req_one_access_txt = "7;29"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15710,9 +15536,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "jNE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -15776,12 +15600,10 @@
 "jPo" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15966,9 +15788,7 @@
 "jUn" = (
 /obj/item/fighter_component/engine/heavy/t1,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jUA" = (
 /obj/structure/chair{
 	dir = 4
@@ -15982,11 +15802,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile/dark,
 /area/science/nanite)
+"jUG" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "jUV" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16038,6 +15864,14 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"jVH" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "jVM" = (
 /turf/open/openspace,
 /area/maintenance/nsv/deck1/starboard)
@@ -16069,8 +15903,7 @@
 /area/engine/break_room)
 "jYe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16105,16 +15938,12 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jYN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "jYQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16230,19 +16059,24 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "kbm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics/mechbay)
+"kbv" = (
+/obj/structure/cable{
+	icon_state = "4-10"
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/bridge)
 "kch" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Auxiliary Shuttle Dock"
@@ -16250,9 +16084,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kci" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
@@ -16285,6 +16117,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/bridge)
+"kcZ" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/frame3/central)
 "kdu" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -16297,13 +16133,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "kdv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/rack,
@@ -16386,14 +16219,17 @@
 "kfn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/carpet/red,
 /area/security/processing)
+"kfy" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/grid/lino,
+/area/security/detectives_office)
 "kgh" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Old Bar"
@@ -16429,9 +16265,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kgV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16555,9 +16389,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/ship/padded,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kkk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
@@ -16638,19 +16470,18 @@
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "kni" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
-	},
+/obj/machinery/status_display/ai/north,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
-/obj/machinery/status_display/ai/north,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame3/central)
 "knr" = (
@@ -16687,9 +16518,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "kom" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -16708,9 +16537,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "koQ" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell/potato,
@@ -16723,9 +16550,6 @@
 	},
 /obj/item/gps{
 	gpstag = "RD0"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Research Division - Lobby";
@@ -16743,8 +16567,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame2/central)
@@ -16754,9 +16578,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kps" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16768,6 +16590,9 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/nsv/deck1/port)
+"kpx" = (
+/turf/open/floor/engine,
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "kpN" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16792,9 +16617,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kqm" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
@@ -16811,9 +16634,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kqp" = (
 /obj/structure/rack,
 /obj/item/circuitboard/computer/libraryconsole,
@@ -16836,21 +16657,17 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "krJ" = (
 /obj/structure/lattice,
 /turf/open/space,
 /area/ai_monitored/turret_protected/AIsatextAP)
 "krW" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/camera/autoname,
@@ -16858,13 +16675,11 @@
 /area/hallway/nsv/deck1/frame3/central)
 "ksa" = (
 /obj/effect/turf_decal/tile/ship/blue{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/science/lab)
@@ -16880,15 +16695,14 @@
 "kso" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
 "ksq" = (
 /obj/structure/table/glass,
 /obj/item/key/fighter_tug,
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ksK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16902,8 +16716,7 @@
 /area/security/checkpoint)
 "ksZ" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16964,9 +16777,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kvf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -17056,6 +16867,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "kxD" = (
@@ -17072,9 +16884,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kxF" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -17098,6 +16908,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
+"kxP" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/nsv/bridge)
 "kxV" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -17144,11 +16960,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering)
 "kyt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
@@ -17162,9 +16984,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "kyM" = (
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -17175,6 +16995,7 @@
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "kzl" = (
@@ -17203,9 +17024,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kAz" = (
 /obj/machinery/door/airlock/ship/public/glass/turbolift,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -17264,13 +17083,10 @@
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kCt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger)
@@ -17313,8 +17129,7 @@
 "kDf" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -17348,9 +17163,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kER" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser,
@@ -17367,9 +17180,6 @@
 	receive_ore_updates = 1
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
 /turf/open/floor/monotile/dark,
 /area/science/lab)
 "kEX" = (
@@ -17472,12 +17282,10 @@
 /area/engine/atmospherics_engine)
 "kJL" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/disposalpipe/segment,
@@ -17495,8 +17303,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/storage/tech)
@@ -17632,8 +17439,7 @@
 /area/security/prison)
 "kPj" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/disposalpipe/segment,
@@ -17658,17 +17464,14 @@
 "kQa" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
 	name = "Armour Pump Subsystem";
 	req_one_access_txt = "10"
 	},
 /turf/open/floor/monotile,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "kQs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -17710,8 +17513,7 @@
 /area/security/processing)
 "kRq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -17748,8 +17550,7 @@
 "kSi" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/grid/mono,
@@ -17781,9 +17582,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "kSr" = (
 /obj/structure/closet/secure_closet/hos,
 /turf/open/floor/monotile,
@@ -17857,6 +17656,24 @@
 "kTR" = (
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
+"kUc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/frame1/central)
 "kUG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/reagent_dispensers/fueltank,
@@ -17917,19 +17734,16 @@
 /obj/structure/cable/yellow,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "kVx" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
@@ -17954,9 +17768,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kVU" = (
 /obj/structure/lattice,
 /obj/effect/landmark/carpspawn,
@@ -17971,6 +17783,13 @@
 /obj/effect/landmark/start/chief_engineer,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/heads/chief)
+"kWu" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/open/floor/engine,
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "kWR" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -18008,9 +17827,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kXX" = (
 /obj/machinery/newscaster,
 /turf/closed/wall/r_wall/ship,
@@ -18023,9 +17840,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kYy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -18047,15 +17862,18 @@
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "kYA" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/closet/radiation,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/maintenance/nsv/bridge)
+/area/maintenance/nsv/deck1/port)
 "kYF" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame3/central)
@@ -18067,18 +17885,19 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/closet/firecloset,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/closet/secure_closet/engineering_welding{
+	anchored = 1;
+	name = "munitions welding supplies locker";
+	req_access = null;
+	req_one_access_txt = "69"
+	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kZf" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "kZk" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/cable{
@@ -18104,6 +17923,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grid/lino,
 /area/security/detectives_office)
 "kZO" = (
@@ -18118,8 +17938,7 @@
 /area/ai_monitored/turret_protected/AIsatextAP)
 "lae" = (
 /obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Left";
-	req_one_access_txt = "0"
+	name = "Air Control Left"
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -18157,9 +17976,7 @@
 /obj/item/folder/blue,
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "lbf" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -18193,9 +18010,7 @@
 /obj/structure/chair/office,
 /obj/effect/landmark/start/head_of_personnel,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "lbZ" = (
 /obj/machinery/armour_plating_nanorepair_pump/forward_port{
 	apnw_id = "pegasusmain"
@@ -18204,9 +18019,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "lcJ" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -18271,9 +18084,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "lfq" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -18285,11 +18096,17 @@
 /turf/open/floor/monotile,
 /area/engine/break_room)
 "lfF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/nsv/deck1/starboard)
+/obj/structure/closet/firecloset/full,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck1/port)
 "lfW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
@@ -18373,17 +18190,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/engine/storage)
 "liM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ljj" = (
 /obj/structure/rack,
 /obj/item/ammo_box/magazine/m45,
@@ -18429,9 +18244,7 @@
 "lkh" = (
 /obj/item/fighter_component/fuel_tank/t1,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "lkv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
 	dir = 1
@@ -18495,8 +18308,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
@@ -18549,9 +18361,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "loH" = (
 /obj/machinery/light_switch/north,
 /turf/open/floor/monotile,
@@ -18577,9 +18387,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "lpJ" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/disposalpipe/segment{
@@ -18597,6 +18405,9 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "lqW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -18650,16 +18461,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "lsw" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/poddoor/ship{
@@ -18669,10 +18477,10 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "ltk" = (
 /obj/machinery/atmospherics/components/binary/pump/layer1{
-	name = "C02 -> Stormdrive Flavouriser"
+	name = "C02 to Stormdrive Flavouriser"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	name = "C02 -> Mix"
+	name = "C02 to Mix"
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/monotile,
@@ -18692,9 +18500,7 @@
 "ltY" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "lui" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine,
@@ -18713,8 +18519,7 @@
 /area/hallway/nsv/deck1/frame1/central)
 "lwQ" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/monotile,
@@ -18792,9 +18597,6 @@
 	name = "Intelligence Core";
 	req_one_access_txt = "16"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
@@ -18805,8 +18607,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
@@ -18822,9 +18623,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "lyQ" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #5";
@@ -18851,8 +18650,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/open/floor/carpet/red,
 /area/security/processing)
@@ -18902,8 +18700,16 @@
 	dir = 8
 	},
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering)
+"lAD" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "lAT" = (
 /obj/machinery/shuttle_manipulator{
 	layer = 2.75;
@@ -18913,9 +18719,7 @@
 	dir = 5
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "lBf" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -18923,17 +18727,14 @@
 /turf/open/floor/monotile,
 /area/science/lab)
 "lBD" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/storage/tech)
@@ -18946,9 +18747,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "lBM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -19019,9 +18818,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "lEr" = (
 /obj/structure/bed/dogbed/ian{
 	color = "";
@@ -19032,9 +18829,7 @@
 	name = "Min-ian"
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "lEu" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -19091,11 +18886,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "lFO" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "lGh" = (
@@ -19114,12 +18907,10 @@
 /area/shuttle/turbolift/tertiary)
 "lHa" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -19165,8 +18956,7 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -19197,9 +18987,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "lJh" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/tile/yellow{
@@ -19215,16 +19003,13 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "lJP" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/grid/mono,
@@ -19263,8 +19048,7 @@
 /area/maintenance/nsv/deck1/starboard)
 "lLV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
@@ -19276,9 +19060,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/effect/landmark/nuclear_waste_spawner,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
 "lMs" = (
@@ -19300,8 +19085,7 @@
 /area/security/warden)
 "lNi" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -19338,11 +19122,8 @@
 "lNH" = (
 /obj/machinery/holopad,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "lNM" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 1
@@ -19351,6 +19132,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/monotile,
 /area/engine/atmos)
 "lOj" = (
@@ -19359,12 +19141,13 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "lOs" = (
 /obj/structure/ladder,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating{
@@ -19402,9 +19185,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "lQW" = (
 /obj/machinery/computer/robotics{
 	dir = 4
@@ -19431,10 +19212,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "lRO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -19537,6 +19319,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
+"lUo" = (
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/ship/delivery/yellow,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/frame3/central)
 "lUs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/red,
@@ -19581,9 +19374,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "lWJ" = (
 /obj/effect/spawner/room/threexthree,
 /turf/template_noop,
@@ -19599,8 +19390,7 @@
 "lXc" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/landmark/zebra_interlock_point,
@@ -19630,15 +19420,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
 /turf/open/floor/carpet/red,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "lYB" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 9
@@ -19648,7 +19435,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "Flavouriser -> Mix"
+	name = "Flavouriser to Mix"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -19751,9 +19538,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "mdv" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/monotile,
@@ -19783,14 +19568,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/firedoor,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "men" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame2/central)
@@ -19832,8 +19614,7 @@
 /area/maintenance/nsv/deck1/starboard)
 "mfM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -19849,9 +19630,7 @@
 "mgj" = (
 /obj/machinery/photocopier,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "mgt" = (
 /obj/item/storage/secure/safe{
 	pixel_x = 32
@@ -19868,19 +19647,24 @@
 /area/security/detectives_office)
 "mgT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "mhk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
+"mhq" = (
+/obj/structure/cable{
+	icon_state = "5-10"
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/bridge)
 "mhy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4
@@ -19902,9 +19686,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/overmap/fighter/utility/prebuilt/carrier,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "mhM" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19932,8 +19714,7 @@
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1;
-	icon_state = "warninglinecorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -19958,6 +19739,7 @@
 	c_tag = "Teleporter Room";
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/monotile/dark,
 /area/teleporter)
 "miR" = (
@@ -19976,9 +19758,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "mjb" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -20032,9 +19812,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "mls" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -20073,6 +19851,14 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
+"mmr" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/monotile/dark,
+/area/science)
 "mnf" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -20091,9 +19877,7 @@
 	},
 /obj/item/ship_weapon/ammunition/torpedo/decoy,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "mnl" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
@@ -20139,12 +19923,12 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "mnR" = (
-/obj/machinery/camera/autoname{
-	dir = 4;
-	icon_state = "camera"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame3/central)
@@ -20185,6 +19969,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/security/prison)
@@ -20285,9 +20072,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "msn" = (
 /obj/structure/displaycase/labcage,
 /obj/structure/cable{
@@ -20346,15 +20131,11 @@
 /obj/machinery/suit_storage_unit/pilot,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "muu" = (
 /obj/machinery/suit_storage_unit/pilot,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "muv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
@@ -20524,6 +20305,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/nsv/deck1/port)
+"myd" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/nsv/deck1/starboard)
 "myl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -20532,9 +20319,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "myB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -20665,9 +20450,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "mDT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20700,9 +20483,7 @@
 /obj/machinery/airalarm/directional/west,
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet/red,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "mFx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -20744,16 +20525,13 @@
 /area/ai_monitored/turret_protected/AIsatextAP)
 "mGe" = (
 /obj/machinery/computer/communications{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "mGy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -20792,6 +20570,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering)
@@ -20854,17 +20635,13 @@
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "mIj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "mIu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20885,14 +20662,24 @@
 /area/hallway/nsv/deck1/frame3/central)
 "mIH" = (
 /turf/closed/wall/r_wall,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "mIO" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
+"mIS" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/monotile,
+/area/engine/atmos)
 "mIT" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -20904,8 +20691,7 @@
 /area/security/detectives_office)
 "mJm" = (
 /obj/effect/turf_decal/tile/ship/blue{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -20916,8 +20702,7 @@
 "mJz" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/grid/mono,
@@ -20949,9 +20734,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/grid/techfloor,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "mKi" = (
 /obj/structure/hull_plate/end{
 	dir = 8
@@ -21024,9 +20807,7 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
 	dir = 4
 	},
-/obj/machinery/advanced_airlock_controller/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/advanced_airlock_controller/directional/north,
 /turf/open/floor/engine,
 /area/engine/atmos)
 "mMF" = (
@@ -21046,13 +20827,11 @@
 	},
 /obj/machinery/door/airlock/ship/engineering{
 	dir = 8;
-	icon_state = "closed";
 	name = "Reactor Core";
 	req_one_access_txt = "32;11"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -21076,13 +20855,10 @@
 /area/ai_monitored/turret_protected/aisat/service)
 "mNb" = (
 /obj/structure/sign/ship/securearea/alt{
-	dir = 4;
-	icon_state = "securearea2"
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "mNv" = (
 /obj/structure/hull_plate/end,
 /turf/open/floor/engine/airless,
@@ -21111,6 +20887,9 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/prison)
 "mOj" = (
@@ -21119,7 +20898,6 @@
 	},
 /obj/structure/sign/ship/smoking{
 	dir = 4;
-	icon_state = "smoking";
 	pixel_x = -32
 	},
 /obj/effect/landmark/start/master_at_arms,
@@ -21189,6 +20967,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating{
@@ -21268,6 +21049,15 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/ai_monitored/turret_protected/AIsatextAP)
+"mVx" = (
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-6"
+	},
+/turf/open/floor/plating,
+/area/nsv/weapons/gauss/battery/deck1/port)
 "mVJ" = (
 /obj/machinery/sparker/toxmix{
 	pixel_x = 25
@@ -21369,13 +21159,8 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "mYf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
 	},
@@ -21444,19 +21229,17 @@
 /area/security/prison)
 "mZX" = (
 /obj/machinery/atmospherics/components/binary/pump/layer1{
-	name = "Mix -> Distro"
+	name = "Mix to Distro"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
 "nae" = (
 /obj/structure/sign/ship/nosmoking{
 	dir = 8;
-	icon_state = "nosmoking";
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -21479,8 +21262,7 @@
 /area/engine/atmos)
 "naz" = (
 /obj/machinery/computer/mech_bay_power_console{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -21498,17 +21280,13 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/engine,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "nbJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nbT" = (
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame1/central)
@@ -21556,14 +21334,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/purple,
 /area/science)
 "ncD" = (
 /obj/structure/table/wood,
 /obj/item/light/bulb,
 /obj/machinery/light/small/built{
-	dir = 1;
-	icon_state = "bulb-empty"
+	dir = 1
 	},
 /turf/open/floor/carpet/ship,
 /area/maintenance/nsv/bridge)
@@ -21587,13 +21365,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ndp" = (
 /obj/structure/cable{
 	icon_state = "6-8"
@@ -21653,13 +21428,10 @@
 /area/engine/atmos)
 "neA" = (
 /obj/effect/turf_decal/stripes/end{
-	dir = 4;
-	icon_state = "warn_end"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "neH" = (
 /obj/machinery/door/airlock/ship/command{
 	name = "Gravity Generator";
@@ -21667,6 +21439,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-6"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "nfg" = (
@@ -21680,9 +21458,7 @@
 	},
 /obj/structure/overmap/fighter/utility/prebuilt/carrier,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nfy" = (
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Intelligence Core Antechamber";
@@ -21695,8 +21471,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -21724,8 +21499,7 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "nif" = (
 /obj/structure/chair/sofa/corner{
-	dir = 1;
-	icon_state = "sofacorner"
+	dir = 1
 	},
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/newscaster/directional/north,
@@ -21802,12 +21576,10 @@
 /area/engine/atmos)
 "njP" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame3/central)
@@ -21818,9 +21590,7 @@
 	pixel_y = -96
 	},
 /turf/open/floor/engine,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "nkF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -21830,9 +21600,10 @@
 /area/maintenance/nsv/deck1/port)
 "nkX" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
-/obj/machinery/camera{
-	c_tag = "Atmospherics - Starboard";
-	dir = 4
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -21851,12 +21622,10 @@
 /turf/open/floor/engine,
 /area/engine/atmos)
 "nlz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/visible/layer1,
 /turf/open/floor/carpet/purple,
 /area/science)
 "nlG" = (
@@ -21869,9 +21638,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"nmY" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
 "nok" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Research wing maintenance";
@@ -21893,8 +21667,7 @@
 /area/storage/tech)
 "noP" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8;
-	icon_state = "warningline"
+	dir = 8
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -21904,9 +21677,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "noQ" = (
 /obj/structure/railing{
 	dir = 8
@@ -21956,6 +21727,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/storage)
 "nrK" = (
@@ -21963,9 +21737,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nrM" = (
 /obj/machinery/door/poddoor/ship/preopen{
 	id = "fighterfighterworkshop";
@@ -21974,9 +21746,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nrY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -21999,20 +21769,16 @@
 "ntr" = (
 /obj/machinery/door/airlock/ship/engineering{
 	dir = 8;
-	icon_state = "closed";
 	name = "Reactor Core";
 	req_one_access_txt = "32;11"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "ntZ" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
 	},
@@ -22024,9 +21790,7 @@
 "nui" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nuy" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 4
@@ -22048,6 +21812,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
+"nvh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3{
+	dir = 9
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nvo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22110,13 +21880,12 @@
 	name = "External shutters"
 	},
 /turf/closed/wall/r_wall,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nyc" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "nyw" = (
@@ -22133,15 +21902,26 @@
 	req_one_access_txt = "69"
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nyN" = (
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"nzh" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2
+	},
+/turf/open/floor/monotile,
+/area/maintenance/nsv/deck1/starboard)
 "nzj" = (
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/monotile,
@@ -22178,8 +21958,7 @@
 /area/crew_quarters/heads/hor)
 "nAm" = (
 /obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Left";
-	req_one_access_txt = "0"
+	name = "Air Control Left"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -22228,6 +22007,15 @@
 /obj/structure/sign/ship/armoury,
 /turf/closed/wall/r_wall,
 /area/security/main)
+"nBt" = (
+/obj/machinery/meter{
+	name = "Oxygen Outlet Readout";
+	pixel_x = 5;
+	pixel_y = 5;
+	target_layer = 3
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "nBx" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -22248,9 +22036,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nDv" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #4";
@@ -22288,12 +22074,10 @@
 /area/science/robotics)
 "nEl" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/button/door{
 	id = "teleroom";
@@ -22321,9 +22105,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nFd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -22434,9 +22216,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nIa" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes/line{
@@ -22448,13 +22228,10 @@
 /obj/item/clothing/head/radiation,
 /obj/item/clothing/suit/radiation,
 /turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "nJj" = (
 /obj/effect/turf_decal/tile/ship/half/blue{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
@@ -22516,8 +22293,7 @@
 /area/space/nearstation)
 "nLZ" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -22598,16 +22374,13 @@
 /area/maintenance/nsv/deck1/starboard)
 "nOy" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame2/central)
@@ -22703,20 +22476,28 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
-"nRR" = (
+"nRy" = (
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
+"nRR" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-9"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
 "nSg" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -22747,17 +22528,13 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nTN" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/plasteel/grid/mono,
@@ -22773,6 +22550,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
 	name = "biohazard containment door"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
 /area/science/server)
@@ -22802,9 +22582,7 @@
 	name = "Auxiliary Flight Pod"
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "nUW" = (
 /obj/structure/reagent_dispensers/fueltank/aviation_fuel,
 /obj/machinery/airalarm{
@@ -22829,9 +22607,7 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "nVO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22925,9 +22701,6 @@
 	name = "Captain's Meeting Room";
 	req_one_access_txt = "20"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -22953,6 +22726,9 @@
 /area/tcommsat/server)
 "nYo" = (
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -22965,8 +22741,7 @@
 /area/science/xenobiology)
 "nZm" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -22989,9 +22764,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "oab" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -23021,12 +22794,10 @@
 /area/engine/engine_room)
 "oaI" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
@@ -23079,9 +22850,9 @@
 /area/engine/atmospherics_engine)
 "ocd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/camera/autoname{
-	dir = 4;
-	icon_state = "camera"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame3/central)
@@ -23143,9 +22914,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "odP" = (
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/under/rank/prisoner,
@@ -23176,16 +22945,23 @@
 /area/security/warden)
 "oeC" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
 	},
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/frame2/central)
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "oeW" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -23252,8 +23028,7 @@
 /area/science/lab)
 "ogq" = (
 /obj/effect/turf_decal/arrows{
-	dir = 8;
-	icon_state = "arrows"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -23275,6 +23050,13 @@
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger/notkmcstupidhanger)
+"ohg" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 8
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/monotile,
+/area/maintenance/nsv/bridge)
 "ohA" = (
 /obj/machinery/igniter/on,
 /turf/open/floor/engine/airless,
@@ -23324,6 +23106,10 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/engine/engine_room)
+"ojM" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/monotile,
+/area/maintenance/nsv/bridge)
 "ojR" = (
 /obj/structure/cable{
 	icon_state = "1-6"
@@ -23383,40 +23169,31 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "okU" = (
 /turf/open/floor/fakespace,
 /area/science/lab)
 "olt" = (
 /obj/machinery/computer/communications/console{
-	dir = 1;
-	icon_state = "computer_end"
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "olw" = (
 /obj/machinery/camera/autoname,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "oma" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/grid/mono,
@@ -23433,9 +23210,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "omK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23547,8 +23322,7 @@
 /area/maintenance/nsv/deck1/starboard)
 "oqk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
@@ -23572,6 +23346,9 @@
 /area/security/prison)
 "osb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -23592,8 +23369,7 @@
 /area/science/mixing)
 "osS" = (
 /obj/effect/turf_decal/caution{
-	dir = 8;
-	icon_state = "caution"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/nsv/hanger/notkmcstupidhanger)
@@ -23624,8 +23400,7 @@
 "otK" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/break_room)
@@ -23640,18 +23415,15 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable,
 /turf/open/floor/monotile,
 /area/engine/gravity_generator)
 "oun" = (
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_x = 1
 	},
 /turf/closed/wall/r_wall,
@@ -23692,12 +23464,10 @@
 "ovb" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23716,8 +23486,7 @@
 /area/hallway/nsv/deck1/frame1/central)
 "ovU" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
@@ -23750,6 +23519,10 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
+"oxp" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
 "oxB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23769,7 +23542,6 @@
 /area/engine/break_room)
 "oye" = (
 /obj/structure/table/wood,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
@@ -23780,6 +23552,14 @@
 /obj/item/flashlight/seclite,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
+"oyo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "captainofficeshutters"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/nsv/briefingroom)
 "oyq" = (
 /obj/structure/chair/sofa,
 /obj/effect/landmark/start/depsec/engineering,
@@ -23789,12 +23569,10 @@
 "oyI" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/security/main)
@@ -23809,14 +23587,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/effect/landmark/start/captain,
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "oze" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -23855,6 +23630,9 @@
 	dir = 1;
 	sortType = 15
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame2/central)
 "oAN" = (
@@ -23872,13 +23650,10 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "oAQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/fakespace,
 /area/maintenance/nsv/bridge)
@@ -23896,17 +23671,14 @@
 /turf/open/floor/monotile,
 /area/security/checkpoint)
 "oAZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23933,9 +23705,7 @@
 	dir = 9
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "oCK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24005,9 +23775,7 @@
 	c_tag = "Starboard Gauss Battery"
 	},
 /turf/open/floor/engine,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "oEM" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/command,
@@ -24091,16 +23859,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship,
 /area/science)
 "oIJ" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/grid/mono,
@@ -24122,9 +23889,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "oJl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24146,9 +23911,7 @@
 /obj/item/radio/intercom/directional/east,
 /obj/item/airlock_painter,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "oJO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
@@ -24219,9 +23982,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "oMk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24296,13 +24057,10 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "oQi" = (
 /obj/machinery/computer/ship/dradis/minor{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/notkmcstupidhanger)
@@ -24323,8 +24081,8 @@
 /area/engine/break_room)
 "oQC" = (
 /obj/effect/turf_decal/box,
-/obj/structure/closet/firecloset,
 /obj/machinery/computer/ship/viewscreen,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/grid/steel,
 /area/nsv/hanger/notkmcstupidhanger)
 "oQR" = (
@@ -24406,8 +24164,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
@@ -24429,6 +24186,9 @@
 	},
 /turf/open/floor/monotile,
 /area/security/prison)
+"oSH" = (
+/turf/open/floor/monotile,
+/area/maintenance/nsv/deck1/starboard)
 "oSK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/secure_data/laptop,
@@ -24545,6 +24305,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet/blue,
 /area/engine/engine_room)
 "oYy" = (
@@ -24600,8 +24361,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/chief)
@@ -24609,9 +24369,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "oZC" = (
 /obj/structure/cable{
 	icon_state = "5-10"
@@ -24647,9 +24405,7 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "paM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24707,15 +24463,11 @@
 	req_one_access_txt = "3;69"
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "pbP" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "pcD" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -24809,9 +24561,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "peR" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -24838,15 +24588,13 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/security/checkpoint/engineering)
@@ -24893,6 +24641,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "phV" = (
@@ -24917,6 +24668,7 @@
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -24972,9 +24724,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "pkJ" = (
 /obj/machinery/door/firedoor/border_only/directional,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -24984,11 +24734,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "pkL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -25013,6 +24765,9 @@
 /obj/structure/cable{
 	icon_state = "5-10"
 	},
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/bridge)
 "plW" = (
@@ -25021,9 +24776,7 @@
 /turf/open/floor/monotile/dark,
 /area/science/mixing)
 "pmo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
 "pmD" = (
@@ -25060,9 +24813,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "pnH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4
@@ -25105,9 +24856,7 @@
 	dir = 9
 	},
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "ppO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
@@ -25189,6 +24938,10 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/security/detectives_office)
+"prS" = (
+/obj/structure/sign/ship/deck,
+/turf/closed/wall/steel,
+/area/hallway/nsv/deck1/frame3/central)
 "psa" = (
 /obj/item/target/alien/anchored,
 /obj/effect/turf_decal/stripes/line{
@@ -25203,8 +24956,7 @@
 	dir = 6
 	},
 /obj/machinery/computer/mech_bay_power_console{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics/mechbay)
@@ -25312,9 +25064,7 @@
 	},
 /obj/machinery/light/runway/delay3,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "pyc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -25329,15 +25079,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/nuke_storage)
 "pyk" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25346,8 +25094,7 @@
 /area/hallway/nsv/deck1/frame2/central)
 "pyq" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/security/prison)
@@ -25485,9 +25232,7 @@
 	layer = 3
 	},
 /turf/open/floor/engine,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "pCW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25521,6 +25266,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/main)
 "pEE" = (
@@ -25534,15 +25282,13 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/airlock/ship/engineering/glass{
 	name = "Engineering Lobby";
@@ -25551,9 +25297,6 @@
 /turf/open/floor/monotile,
 /area/engine/engineering)
 "pEF" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -25562,6 +25305,12 @@
 	},
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
+	dir = 10
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
@@ -25573,9 +25322,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "pEO" = (
 /obj/structure/table/reinforced,
 /obj/item/multitool,
@@ -25608,6 +25355,17 @@
 	},
 /turf/open/floor/monotile,
 /area/science)
+"pFH" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/frame3/central)
 "pFL" = (
 /obj/item/radio/intercom/directional/west,
 /obj/item/fighter_component/countermeasure_dispenser/t1,
@@ -25643,7 +25401,6 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame2/central)
 "pHf" = (
@@ -25661,15 +25418,12 @@
 /area/engine/engine_smes)
 "pHo" = (
 /obj/machinery/computer/crew/console{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "pHv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -25680,13 +25434,9 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "pHD" = (
-/obj/machinery/computer/lore_terminal{
-	pixel_y = 26
-	},
+/obj/machinery/computer/lore_terminal,
 /turf/open/floor/carpet/blue,
 /area/engine/engine_room)
 "pHH" = (
@@ -25787,12 +25537,10 @@
 "pKR" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -25810,9 +25558,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "pLd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -25837,7 +25583,6 @@
 /area/science/robotics)
 "pLh" = (
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_x = 1
 	},
 /turf/closed/wall/r_wall,
@@ -25865,6 +25610,14 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
+"pMK" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/vending/assist,
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "pMP" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer3{
@@ -25874,29 +25627,23 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "pNb" = (
 /obj/structure/sign/ship/securearea{
 	dir = 4;
 	name = "WARNING: WEAR HEARING PROTECTION"
 	},
 /obj/structure/sign/ship/securearea{
-	dir = 8;
-	icon_state = "securearea"
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/security/processing)
 "pNc" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1;
-	icon_state = "warninglinecorner"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "pNh" = (
 /obj/machinery/light{
 	dir = 4
@@ -25961,19 +25708,27 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/layer1,
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
+"pOY" = (
+/obj/machinery/door/poddoor/ship/preopen{
+	dir = 4;
+	id = "launch_tubes";
+	name = "Launch tubes"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/monotile,
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "pPH" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
 "pPO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "pPP" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/airalarm{
@@ -26004,9 +25759,7 @@
 /area/security/checkpoint/science)
 "pQx" = (
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "pQD" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -26042,8 +25795,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -26067,6 +25819,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/plasteel/ship,
 /area/nsv/hanger/notkmcstupidhanger)
 "pTy" = (
@@ -26084,12 +25837,10 @@
 /area/ai_monitored/turret_protected/ai)
 "pUG" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/plasteel/grid/mono,
@@ -26132,9 +25883,7 @@
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "pVY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -26209,9 +25958,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/closet/secure_closet/bridge,
 /turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "pZW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3{
 	dir = 4
@@ -26254,8 +26001,7 @@
 /area/security/detectives_office)
 "qaB" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -26265,6 +26011,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame2/central)
@@ -26282,11 +26031,11 @@
 /turf/open/floor/monotile,
 /area/security/checkpoint)
 "qbn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-9"
 	},
 /turf/open/floor/plating{
-	icon_state = "platingdmg1"
+	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/bridge)
 "qbt" = (
@@ -26309,6 +26058,9 @@
 "qcS" = (
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/security/detectives_office)
@@ -26355,6 +26107,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
 "qet" = (
@@ -26363,6 +26118,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/carpet/purple,
 /area/science)
@@ -26391,13 +26149,10 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qfW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/machinery/light,
 /turf/open/floor/monotile/dark,
@@ -26463,13 +26218,10 @@
 /area/security/processing)
 "qhQ" = (
 /obj/machinery/computer/security/mining{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "qiy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26520,11 +26272,13 @@
 /area/security/detectives_office)
 "qjQ" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/security/checkpoint)
 "qke" = (
@@ -26673,8 +26427,7 @@
 /area/engine/atmos)
 "qmS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -26715,13 +26468,11 @@
 "qnY" = (
 /obj/machinery/door/airlock/ship/engineering{
 	dir = 8;
-	icon_state = "closed";
 	name = "Reactor Core";
 	req_one_access_txt = "32;11"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -26743,8 +26494,7 @@
 /area/engine/atmospherics_engine)
 "qon" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -26776,20 +26526,30 @@
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/grid/mono,
 /area/maintenance/nsv/deck1/starboard)
 "qrg" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/structure/closet/firecloset/full,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame1/central)
 "qrQ" = (
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plasteel/grid/techfloor,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "qrW" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -26805,9 +26565,7 @@
 /obj/structure/closet/emcloset,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qsN" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
@@ -26845,6 +26603,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/main)
 "qti" = (
@@ -26852,21 +26613,21 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qtk" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/structure/closet/radiation,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
 "quq" = (
-/obj/structure/cable{
-	icon_state = "4-9"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/maintenance/nsv/bridge)
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/port)
 "qur" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -26874,15 +26635,24 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"quD" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/paicard,
+/obj/item/clothing/gloves/color/black,
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "quT" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/structure/sign/ship/nosmoking{
 	dir = 8;
-	icon_state = "nosmoking";
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/grid/mono,
@@ -26901,6 +26671,7 @@
 /area/security/prison)
 "qww" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
 "qwE" = (
@@ -26917,6 +26688,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "qxv" = (
@@ -26951,9 +26723,9 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 9;
-	icon_state = "camera"
+	dir = 9
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/monotile/dark,
 /area/engine/storage)
 "qyz" = (
@@ -27018,9 +26790,7 @@
 	},
 /obj/item/ship_weapon/ammunition/torpedo/decoy,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qzD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27036,9 +26806,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qAg" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -27101,16 +26869,13 @@
 	id = "launch2"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qCA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/science/mixing)
@@ -27120,9 +26885,7 @@
 	name = "briefing room chair"
 	},
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qCQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -27130,9 +26893,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qDa" = (
 /obj/structure/cable{
 	icon_state = "2-5"
@@ -27167,9 +26928,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qEO" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -27228,9 +26987,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "qFq" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -27267,9 +27024,7 @@
 	},
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "qGb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27281,9 +27036,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "qGh" = (
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -27378,9 +27131,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "qJs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -27443,13 +27194,15 @@
 "qKV" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/frame3/central)
+"qLe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame3/central)
 "qLo" = (
@@ -27471,8 +27224,7 @@
 /area/engine/atmospherics_engine)
 "qNo" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -27557,9 +27309,7 @@
 /obj/structure/table/glass,
 /obj/machinery/light_switch/west,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "qQj" = (
 /obj/item/beacon,
 /turf/open/floor/engine,
@@ -27597,9 +27347,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qSc" = (
 /obj/machinery/computer/ship/navigation/public{
 	dir = 8;
@@ -27628,15 +27376,17 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/briefingroom)
 "qSw" = (
-/obj/machinery/computer/lore_terminal{
-	pixel_y = 26
-	},
+/obj/machinery/computer/lore_terminal,
 /obj/machinery/light{
 	dir = 4
 	},
 /mob/living/simple_animal/parrot/Poly,
 /turf/open/floor/plasteel/ship,
 /area/crew_quarters/heads/chief)
+"qSJ" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/frame3/central)
 "qSQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -27663,9 +27413,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qTG" = (
 /obj/machinery/door/airlock/ship/security{
 	name = "Interrogation / Execution Room";
@@ -27690,9 +27438,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qTQ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -27727,14 +27473,14 @@
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "qVM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -27761,8 +27507,7 @@
 /area/security/checkpoint)
 "qWU" = (
 /obj/effect/turf_decal/arrows{
-	dir = 8;
-	icon_state = "arrows"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -27784,6 +27529,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"qYt" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/monotile,
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "qYv" = (
 /obj/machinery/light,
 /turf/open/floor/monotile,
@@ -27797,16 +27548,13 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/end{
-	dir = 8;
-	icon_state = "warn_end"
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/grid/techfloor,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "qZm" = (
 /obj/effect/spawner/room/threexfive,
 /turf/template_noop,
@@ -27931,8 +27679,7 @@
 "rcm" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/landmark/zebra_interlock_point,
@@ -27945,15 +27692,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rcA" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
 "rcO" = (
@@ -27972,15 +27719,16 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "rdz" = (
 /obj/structure/cable{
 	icon_state = "2-9"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/plating{
@@ -27993,6 +27741,9 @@
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/heads/captain)
+"reo" = (
+/turf/closed/wall/r_wall,
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "rep" = (
 /obj/structure/sign/ship/nosmoking{
 	dir = 4
@@ -28011,6 +27762,22 @@
 "rfb" = (
 /turf/open/floor/plasteel/grid/lino,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"rfl" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "rfW" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -28075,8 +27842,7 @@
 "riG" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28111,9 +27877,7 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rjm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28129,6 +27893,15 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
+"rjs" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
 "rjH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28140,9 +27913,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rkp" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
@@ -28174,11 +27945,31 @@
 /area/engine/storage)
 "rlg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger)
+"rlm" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/multitool{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/multitool{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/destTagger{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/t_scanner,
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "rmk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -28193,9 +27984,7 @@
 /area/science/xenobiology)
 "rno" = (
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "rnA" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -28218,8 +28007,11 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "rnK" = (
-/obj/structure/sign/ship/deck,
-/turf/closed/wall/steel,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
 "rnN" = (
 /obj/structure/table/reinforced,
@@ -28253,9 +28045,17 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
+"roo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/turf/open/floor/plating,
+/area/maintenance/nsv/bridge)
 "rop" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -28272,8 +28072,7 @@
 	req_one_access_txt = "56"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -28281,9 +28080,19 @@
 /turf/open/floor/plasteel/ship,
 /area/engine/engineering)
 "roI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/hor)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/nsv/deck1/port)
 "roP" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -28309,13 +28118,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/monotile,
 /area/security/prison)
 "rpa" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame1/central)
 "rpR" = (
@@ -28377,9 +28184,7 @@
 	name = "Auxiliary Flight Pod"
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rqU" = (
 /obj/structure/chair/office,
 /obj/structure/cable/yellow{
@@ -28409,8 +28214,7 @@
 "rrx" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame3/central)
@@ -28420,12 +28224,10 @@
 /area/engine/atmospherics_engine)
 "rrK" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	c_tag = "FTL engine"
@@ -28481,8 +28283,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/engine/break_room)
@@ -28520,8 +28321,7 @@
 /area/security/checkpoint)
 "rva" = (
 /obj/effect/turf_decal/tile/ship/blue{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -28535,9 +28335,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rvB" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -28597,6 +28395,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "rxp" = (
@@ -28704,7 +28503,7 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
-	sortType = 8
+	sortType = 7
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame2/central)
@@ -28760,6 +28559,9 @@
 "rAB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/keycard_auth,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "rAD" = (
@@ -28785,9 +28587,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "rAK" = (
 /obj/machinery/door/poddoor{
 	id = "toxgun";
@@ -28823,9 +28623,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rCv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -28869,9 +28667,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rDl" = (
 /obj/effect/turf_decal/tile/ship/half/blue,
 /obj/effect/turf_decal/tile/ship/half/neutral{
@@ -28896,9 +28692,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "rDQ" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -28915,9 +28709,7 @@
 /area/science/mixing)
 "rFj" = (
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rFA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28925,9 +28717,7 @@
 /obj/effect/turf_decal/box,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rGF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28989,22 +28779,20 @@
 	name = "Launch tubes"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rIL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rJB" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -29020,16 +28808,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rMs" = (
 /obj/structure/table,
 /obj/item/megaphone/command,
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "rMH" = (
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -29069,18 +28853,17 @@
 /turf/closed/wall/steel,
 /area/nsv/briefingroom)
 "rQS" = (
+/obj/structure/grille,
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 5
 	},
-/turf/open/floor/carpet/red,
-/area/security/detectives_office)
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/port)
 "rRv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rRP" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -29091,6 +28874,14 @@
 	},
 /turf/open/floor/plasteel/grid/lino,
 /area/tcommsat/server)
+"rRU" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/vending/tool,
+/turf/open/floor/plasteel/grid/mono,
+/area/maintenance/nsv/deck1/starboard)
 "rSb" = (
 /obj/machinery/atmospherics/pipe/simple/brown/visible/layer3{
 	dir = 5
@@ -29131,11 +28922,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/security/main)
@@ -29147,8 +28936,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -29170,9 +28958,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "rTL" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input,
 /turf/open/floor/engine/o2,
@@ -29185,9 +28971,6 @@
 	},
 /area/maintenance/nsv/deck1/starboard)
 "rTY" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -29235,9 +29018,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "rVZ" = (
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Primary Hangar Bay";
@@ -29283,8 +29064,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/service)
@@ -29292,6 +29072,10 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"rYl" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/monotile,
+/area/maintenance/nsv/bridge)
 "rYJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -29320,8 +29104,7 @@
 	},
 /obj/item/cartridge/atmos,
 /obj/machinery/camera/autoname{
-	dir = 1;
-	icon_state = "camera"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29343,9 +29126,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "rZi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29431,6 +29212,9 @@
 /obj/item/phone{
 	name = "Tech Support"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/science/server)
 "scq" = (
@@ -29439,16 +29223,14 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "scE" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/north,
+/obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
 "scV" = (
 /obj/machinery/camera/motion{
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/storage/tech)
@@ -29456,7 +29238,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/components/binary/pump/layer1{
 	dir = 8;
-	name = "Port -> Hot Heat Exchanger"
+	name = "Port to Hot Heat Exchanger"
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -29478,14 +29260,14 @@
 /turf/open/floor/monotile,
 /area/engine/atmos)
 "sej" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/newscaster{
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
@@ -29499,9 +29281,7 @@
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "sfk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -29538,9 +29318,6 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
 "sgC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -29549,6 +29326,9 @@
 	},
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	req_one_access_txt = "69"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
@@ -29603,8 +29383,27 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/prison)
+"sjs" = (
+/obj/effect/turf_decal/tile/ship/half/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/monotile,
+/area/security/main)
 "sju" = (
 /obj/machinery/computer/card/minor/ce{
 	dir = 4
@@ -29680,8 +29479,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
@@ -29740,9 +29538,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "snb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29761,15 +29557,7 @@
 	id = "launch1"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
-"snk" = (
-/obj/machinery/disposal/bin,
-/turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "snm" = (
 /obj/effect/turf_decal/tile/ship/half/red,
 /obj/structure/cable{
@@ -29784,8 +29572,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/prison)
+"snr" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck1/starboard)
 "snL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -29835,8 +29632,7 @@
 "soR" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29853,9 +29649,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "spl" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 10
@@ -29943,6 +29737,9 @@
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -30014,9 +29811,7 @@
 "stO" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "stZ" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -30032,8 +29827,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
@@ -30046,9 +29840,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "suO" = (
 /obj/machinery/atmospherics/pipe/manifold/brown/visible/layer3{
 	dir = 1
@@ -30097,17 +29889,13 @@
 	pixel_x = -22
 	},
 /turf/open/floor/engine,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "swm" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30138,8 +29926,7 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "sxw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-10"
@@ -30192,9 +29979,7 @@
 	dir = 5
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "szA" = (
 /obj/structure/railing,
 /turf/open/floor/monotile,
@@ -30234,9 +30019,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "sAr" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -30282,12 +30065,10 @@
 /area/ai_monitored/turret_protected/AIsatextAP)
 "sCh" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30301,6 +30082,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/prison)
 "sCz" = (
@@ -30339,9 +30123,7 @@
 	},
 /obj/item/ship_weapon/ammunition/torpedo/decoy,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "sCL" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -30378,6 +30160,19 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/engine/airless,
 /area/engine/engine_room)
+"sDN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "hopoffice"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint)
 "sEh" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -30403,7 +30198,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/hor)
 "sEN" = (
@@ -30439,9 +30233,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "sGb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -30483,7 +30275,7 @@
 "sHl" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "Mix -> Ports"
+	name = "Mix to Ports"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -30545,8 +30337,7 @@
 /area/engine/engine_smes)
 "sJo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
@@ -30651,13 +30442,12 @@
 /turf/open/floor/monotile/dark,
 /area/teleporter)
 "sMP" = (
-/obj/effect/turf_decal/tile/ship/half/green,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/monotile,
-/area/hallway/nsv/deck1/frame1/central)
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/port)
 "sNd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30706,8 +30496,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grid/techfloor,
 /area/tcommsat/server)
@@ -30751,9 +30540,7 @@
 	dir = 6
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "sOP" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/stripes/line{
@@ -30763,9 +30550,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "sPf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30785,9 +30570,7 @@
 	name = "Executive Officer"
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "sPq" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -30838,13 +30621,10 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "sQK" = (
 /obj/structure/holohoop{
 	dir = 4;
-	icon_state = "hoop";
 	layer = 4.1
 	},
 /obj/machinery/camera/autoname{
@@ -30877,13 +30657,10 @@
 "sRc" = (
 /obj/machinery/ship_weapon/gauss_gun/north,
 /turf/open/floor/engine,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "sRe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/carpet/purple,
 /area/science)
@@ -30955,17 +30732,13 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "sVn" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -31025,8 +30798,7 @@
 /area/tcommsat/server)
 "sWN" = (
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -31085,9 +30857,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "sZJ" = (
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -31102,6 +30872,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame2/central)
 "taw" = (
@@ -31116,6 +30887,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger)
+"taQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/monotile/dark,
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tbs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31156,9 +30934,7 @@
 /area/security/prison)
 "tcy" = (
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tcK" = (
 /obj/structure/rack,
 /obj/item/storage/box/teargas,
@@ -31214,7 +30990,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/binary/pump/on/layer3{
 	dir = 4;
-	name = "Waste -> Pure"
+	name = "Waste to Pure"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -31229,9 +31005,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "teK" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/medical,
@@ -31342,9 +31116,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tgU" = (
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/monotile/dark,
@@ -31385,8 +31157,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -31408,9 +31179,7 @@
 "tjx" = (
 /obj/item/fighter_component/apu,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tjA" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint)
@@ -31427,6 +31196,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/monotile,
 /area/security/prison)
@@ -31515,15 +31287,11 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "tmT" = (
 /obj/item/fighter_component/primary/heavy/heavy_cannon/t1,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tng" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -31536,8 +31304,9 @@
 /area/nsv/briefingroom)
 "tnr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/monotile/dark,
-/area/science/lab)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/port)
 "tnX" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate{
@@ -31595,6 +31364,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/main)
 "toK" = (
@@ -31618,9 +31390,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tpj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31658,6 +31428,9 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "tpM" = (
@@ -31668,16 +31441,12 @@
 /area/space/nearstation)
 "tqk" = (
 /obj/structure/chair/sofa/corner{
-	dir = 1;
-	icon_state = "sofacorner"
+	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
 "tqq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
@@ -31721,9 +31490,7 @@
 	dir = 6
 	},
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "tsM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -31732,16 +31499,25 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"tsZ" = (
+/obj/structure/cable{
+	icon_state = "5-8"
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/nsv/deck1/starboard)
 "ttU" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "Plasma -> Mix"
+	name = "Plasma to Mix"
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -31768,9 +31544,7 @@
 "tuB" = (
 /obj/item/fighter_component/armour_plating/heavy/t1,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tuN" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -31821,9 +31595,7 @@
 	apnw_id = "pegasusmain"
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "txd" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -31917,6 +31689,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
+"tzQ" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/bridge)
 "tAw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -31928,8 +31706,7 @@
 /area/maintenance/nsv/deck1/starboard)
 "tAL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -31939,6 +31716,18 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
+"tAZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tBL" = (
 /obj/machinery/teleport/station,
 /obj/machinery/status_display/evac{
@@ -32046,8 +31835,7 @@
 /area/science/mixing)
 "tDJ" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
@@ -32075,9 +31863,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tEz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
@@ -32134,8 +31920,7 @@
 "tGs" = (
 /obj/structure/ladder,
 /obj/structure/fluff/support_beam{
-	dir = 4;
-	icon_state = "support_beam"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
@@ -32144,16 +31929,15 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/camera/autoname{
-	dir = 4;
-	icon_state = "camera"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "tGJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/ai_monitored/security/armory)
@@ -32206,8 +31990,7 @@
 /obj/effect/landmark/start/depsec/science,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/carpet/red,
 /area/security/checkpoint/science)
@@ -32219,9 +32002,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tHD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
@@ -32278,6 +32059,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/nsv/hanger/notkmcstupidhanger)
+"tKq" = (
+/obj/structure/sign/ship/securearea{
+	dir = 8;
+	name = "WARNING: WEAR HEARING PROTECTION"
+	},
+/turf/closed/wall/r_wall,
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "tKy" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -32293,12 +32081,10 @@
 /area/science)
 "tKz" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32328,8 +32114,7 @@
 /area/science/mixing)
 "tMh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -32342,9 +32127,7 @@
 "tNi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "tNy" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 4
@@ -32353,8 +32136,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/rdservercontrol{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/science/server)
@@ -32366,6 +32148,12 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/nsv/deck1/starboard)
+"tNL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile,
+/area/bridge/cic)
 "tNQ" = (
 /turf/open/floor/plasteel/techmaint,
 /area/engine/storage)
@@ -32403,9 +32191,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tRs" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -32415,9 +32201,7 @@
 /obj/structure/chair/comfy/black,
 /obj/structure/chair/comfy/black,
 /turf/open/floor/carpet/red,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tRT" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot{
@@ -32490,9 +32274,7 @@
 "tTn" = (
 /obj/structure/table/glass,
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tTt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -32527,9 +32309,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "tUE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -32557,18 +32337,14 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tVc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/light/runway/delay2,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "tVd" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32586,14 +32362,11 @@
 	pixel_y = 23
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "tVu" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -32608,8 +32381,7 @@
 "tWw" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
@@ -32654,17 +32426,15 @@
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
 "tZR" = (
-/obj/machinery/atmospherics/components/binary/pump/layer1{
-	name = "O2 -> Stormdrive Fuel Flavouriser"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/on/layer3{
-	dir = 8;
-	filter_type = "o2"
+/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
@@ -32675,8 +32445,7 @@
 	req_one_access_txt = "63"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -32824,8 +32593,15 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/prison)
+"ucN" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
+/area/maintenance/nsv/bridge)
 "ucR" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -32849,9 +32625,7 @@
 	name = "WARNING: WEAR HEARING PROTECTION"
 	},
 /turf/closed/wall/r_wall,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "udm" = (
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "CIC";
@@ -32869,9 +32643,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "uds" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -32884,12 +32656,10 @@
 "udF" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32903,6 +32673,9 @@
 /obj/machinery/door/airlock/ship/security/glass{
 	name = "Long Term Confinement";
 	req_one_access_txt = "2;38"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/security/prison)
@@ -32936,9 +32709,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ueF" = (
 /obj/machinery/button/door{
 	id = "launch_tubes";
@@ -32949,12 +32720,10 @@
 	dir = 1
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ueK" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -32974,9 +32743,7 @@
 /obj/item/ship_weapon/ammunition/torpedo/decoy,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ufi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -33084,8 +32851,7 @@
 /area/hallway/nsv/deck1/frame1/central)
 "ulM" = (
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -33101,9 +32867,27 @@
 	name = "briefing room chair"
 	},
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
+"umj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/ship/delivery/yellow,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/frame3/central)
 "unx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -33115,13 +32899,10 @@
 	pixel_y = 4
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "unV" = (
 /obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	name = "manual inlet valve"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/science/mixing)
@@ -33143,7 +32924,6 @@
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "uoN" = (
@@ -33153,6 +32933,9 @@
 "uoR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
 "upm" = (
@@ -33204,15 +32987,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/storage/eva)
 "uqm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -33235,13 +33014,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "uqO" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/ship/blue{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/coffee,
@@ -33272,22 +33053,24 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/ship,
 /area/engine/storage)
 "urF" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/science/robotics)
 "urG" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "urK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -33309,6 +33092,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering)
@@ -33408,9 +33194,7 @@
 "uuW" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "uvj" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -27
@@ -33436,9 +33220,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "uvz" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8;
@@ -33494,20 +33276,16 @@
 /area/engine/atmos)
 "uxS" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "uyi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/item/ship_weapon/ammunition/torpedo/decoy,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "uyn" = (
 /obj/item/control_rod,
 /obj/item/control_rod,
@@ -33534,6 +33312,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/carpet/ship,
 /area/crew_quarters/heads/captain)
 "uyR" = (
@@ -33548,12 +33329,10 @@
 "uzx" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33605,6 +33384,13 @@
 	},
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
+"uBJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/bridge)
 "uCj" = (
 /obj/structure/chair{
 	dir = 8
@@ -33635,23 +33421,26 @@
 /obj/item/clothing/head/radiation,
 /obj/item/clothing/suit/radiation,
 /turf/open/floor/monotile/dark,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "uCQ" = (
 /obj/structure/table/reinforced,
 /obj/item/phone,
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/security/prison)
+"uCW" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/monotile,
+/area/maintenance/nsv/bridge)
 "uDc" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/ship/blue{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/item/ship_weapon/ammunition/torpedo/probe,
 /obj/machinery/camera{
@@ -33720,9 +33509,7 @@
 "uGI" = (
 /obj/effect/turf_decal/ship/techfloor,
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "uGJ" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/bot,
@@ -33745,29 +33532,23 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "uHV" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai)
 "uJv" = (
-/obj/machinery/advanced_airlock_controller/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/advanced_airlock_controller/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "uJF" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33797,8 +33578,7 @@
 /area/science)
 "uKc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3,
 /turf/open/floor/carpet/orange,
@@ -33806,12 +33586,10 @@
 "uLs" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -33866,9 +33644,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "uOd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -33905,7 +33681,6 @@
 "uQd" = (
 /obj/structure/holohoop{
 	dir = 8;
-	icon_state = "hoop";
 	layer = 4.1
 	},
 /obj/machinery/camera/autoname{
@@ -33964,8 +33739,7 @@
 /area/science/nanite)
 "uRS" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -33974,8 +33748,7 @@
 /area/hallway/nsv/deck1/frame3/central)
 "uRX" = (
 /obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Right";
-	req_one_access_txt = "0"
+	name = "Air Control Right"
 	},
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
@@ -34000,9 +33773,7 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "uTP" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -34029,9 +33800,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "uVo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -34071,9 +33840,7 @@
 "uWF" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "uWG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer1{
 	dir = 6
@@ -34096,9 +33863,7 @@
 /area/security/prison)
 "uWW" = (
 /turf/closed/wall/steel,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "uXe" = (
 /obj/structure/sign/ship/nosmoking{
 	dir = 1
@@ -34139,10 +33904,15 @@
 /turf/open/floor/monotile,
 /area/science/mixing)
 "uXE" = (
-/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Public Tool Storage"
+	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
 "uXJ" = (
 /obj/structure/disposalpipe/segment{
@@ -34173,8 +33943,7 @@
 /area/crew_quarters/heads/hor)
 "uXZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -34185,9 +33954,7 @@
 /obj/structure/rack,
 /obj/item/fighter_component/targeting_sensor/heavy/t1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "uYo" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -34232,10 +33999,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "vae" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -34245,9 +34013,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "vbb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34297,9 +34063,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "vcE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer1,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -34329,8 +34093,7 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "veB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -34350,8 +34113,7 @@
 /area/maintenance/nsv/deck1/starboard)
 "vfk" = (
 /obj/machinery/door/airlock/ship/hatch{
-	name = "Air Control Right";
-	req_one_access_txt = "0"
+	name = "Air Control Right"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -34384,9 +34146,7 @@
 /obj/machinery/holopad,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "vgj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34403,6 +34163,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/storage)
 "vgr" = (
@@ -34470,9 +34233,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "vlb" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -34484,8 +34245,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
@@ -34526,6 +34286,13 @@
 /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
 /turf/open/floor/monotile,
 /area/security/processing)
+"voh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/nsv/deck1/frame3/central)
 "voi" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot,
@@ -34583,6 +34350,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/prison)
 "vpy" = (
@@ -34631,12 +34401,10 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "vqY" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -34652,9 +34420,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "vrw" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -34687,8 +34453,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/nsv/briefingroom)
@@ -34703,20 +34468,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
 /area/engine/engine_room)
 "vsu" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -34728,9 +34490,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer3,
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "vsU" = (
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 4
@@ -34785,9 +34545,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "vtU" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -34806,6 +34564,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/prison)
 "vuC" = (
@@ -34841,9 +34602,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "vvm" = (
 /obj/structure/table/wood,
 /obj/item/camera/detective,
@@ -34867,9 +34626,7 @@
 	dir = 10
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "vwQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -34957,8 +34714,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -34990,13 +34746,15 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
+"vCx" = (
+/turf/open/floor/plating,
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "vCF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -35018,9 +34776,7 @@
 	id = "launch1"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "vDq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -35051,9 +34807,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "vEE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -35093,8 +34847,7 @@
 "vFN" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -35103,6 +34856,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
 "vFT" = (
@@ -35125,6 +34879,13 @@
 /obj/structure/grille,
 /turf/open/floor/engine/airless,
 /area/space)
+"vGZ" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/frame3/central)
 "vHh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/ship/preopen{
@@ -35141,6 +34902,15 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/storage)
+"vHG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
 "vIM" = (
 /obj/machinery/door/airlock/ship/security/glass{
 	id_tag = "pw_fd_outer";
@@ -35184,8 +34954,7 @@
 "vKA" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
-	dir = 1;
-	icon_state = "warningline_red"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35209,9 +34978,7 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -35279,6 +35046,22 @@
 	},
 /turf/open/floor/monotile,
 /area/security/prison)
+"vMq" = (
+/obj/effect/turf_decal/tile/ship/half/red,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/monotile,
+/area/security/main)
 "vME" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
 	dir = 4
@@ -35308,13 +35091,10 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "vNp" = (
 /obj/effect/turf_decal/caution{
-	dir = 8;
-	icon_state = "caution"
+	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "vNQ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/visible,
 /turf/open/floor/monotile/dark,
@@ -35346,8 +35126,7 @@
 /area/tcommsat/server)
 "vOR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -35360,6 +35139,7 @@
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
+/obj/structure/closet/emcloset,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame1/central)
 "vPZ" = (
@@ -35404,6 +35184,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/prison)
 "vQC" = (
@@ -35426,15 +35209,11 @@
 /area/security/prison)
 "vRh" = (
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "vRl" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "vRC" = (
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Auxiliary Flight Pod"
@@ -35445,9 +35224,6 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame3/central)
 "vRZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Primary Hangar Bay";
 	req_one_access_txt = "3;69"
@@ -35484,8 +35260,10 @@
 	icon_state = "4-10"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
@@ -35531,9 +35309,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "vTx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -35548,6 +35324,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
 /area/engine/engineering)
 "vTL" = (
@@ -35574,9 +35351,7 @@
 "vVq" = (
 /obj/structure/table/glass,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "vVL" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - O2";
@@ -35640,8 +35415,7 @@
 "vYD" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/camera/autoname{
-	dir = 9;
-	icon_state = "camera"
+	dir = 9
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -35663,6 +35437,7 @@
 	dir = 8;
 	network = list("interrogation")
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grid/lino,
 /area/security/detectives_office)
 "waj" = (
@@ -35675,10 +35450,15 @@
 	},
 /turf/open/floor/monotile,
 /area/security/checkpoint)
+"wci" = (
+/obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/nsv/bridge)
 "wcp" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/monotile,
@@ -35719,7 +35499,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
 /turf/open/floor/monotile,
@@ -35769,13 +35549,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/camera/preset/toxins,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "wft" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/ship/blue{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/computer/ship/navigation/astrometrics,
 /turf/open/floor/monotile,
@@ -35806,9 +35586,7 @@
 	req_one_access_txt = "10"
 	},
 /turf/open/floor/monotile,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "wgn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -35878,13 +35656,10 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "wib" = (
 /obj/effect/turf_decal/stripes/end{
-	dir = 8;
-	icon_state = "warn_end"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger)
@@ -35898,9 +35673,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "wis" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/engine/airless,
@@ -35927,6 +35700,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/monotile,
@@ -36002,7 +35778,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/binary/pump/on/layer1{
-	name = "O2 -> Incinerator"
+	name = "O2 to Incinerator"
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
@@ -36012,9 +35788,7 @@
 /obj/item/pen,
 /obj/item/computer_hardware/card_slot,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "wlA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -36096,9 +35870,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wpr" = (
 /obj/machinery/portable_atmospherics/canister/constricted_plasma,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer1,
@@ -36111,9 +35883,7 @@
 	req_one_access_txt = "2;69"
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wpI" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -36169,6 +35939,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -36225,11 +35996,14 @@
 /turf/closed/wall/steel,
 /area/shuttle/turbolift/secondary)
 "wtf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/space/nearstation)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/nsv/deck1/port)
 "wtE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -36254,12 +36028,18 @@
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/chief)
+"wuY" = (
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/frame1/central)
 "wvH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/grid/lino,
 /area/security/detectives_office)
 "wwd" = (
 /obj/machinery/atmospherics/pipe/simple,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/dark,
 /area/science/server)
 "wwe" = (
@@ -36276,8 +36056,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/engine/engineering)
@@ -36308,14 +36087,11 @@
 /area/engine/engineering)
 "wxJ" = (
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wxQ" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -36361,9 +36137,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "wzR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/cable{
@@ -36457,8 +36231,7 @@
 "wBO" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36490,9 +36263,7 @@
 /area/engine/break_room)
 "wCL" = (
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wDj" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -36513,13 +36284,28 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame3/central)
 "wDQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3,
 /turf/open/floor/engine,
 /area/engine/atmos)
+"wEd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/ship/preopen{
+	id = "hopoffice"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/hallway/nsv/deck1/frame2/central)
 "wEg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -36563,8 +36349,7 @@
 /obj/structure/table/reinforced,
 /obj/item/coin/antagtoken,
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 8
@@ -36575,6 +36360,12 @@
 	},
 /turf/open/floor/monotile,
 /area/security/prison)
+"wFj" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck1/starboard)
 "wFn" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -36592,12 +36383,10 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "wGa" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame3/central)
@@ -36606,7 +36395,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	name = "N2 -> Mix"
+	name = "N2 to Mix"
 	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer1,
 /obj/effect/turf_decal/tile/yellow,
@@ -36662,10 +36451,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-9"
+	},
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/port)
 "wIX" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -36728,9 +36518,7 @@
 "wKT" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "wKX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/item/radio/intercom{
@@ -36793,14 +36581,18 @@
 	},
 /obj/item/key/fighter_tug,
 /turf/open/floor/carpet/blue,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wMq" = (
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grid/mono,
 /area/maintenance/nsv/deck1/starboard)
 "wMz" = (
 /obj/machinery/status_display/evac/north{
@@ -36816,9 +36608,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wMX" = (
 /obj/effect/spawner/room/threexthree,
 /turf/template_noop,
@@ -36852,9 +36642,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wOD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer3,
 /obj/machinery/firealarm{
@@ -36898,9 +36686,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wOZ" = (
 /obj/structure/reagent_dispensers/fueltank/aviation_fuel,
 /obj/machinery/button/door{
@@ -36941,9 +36727,7 @@
 	dir = 6
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wQP" = (
 /obj/machinery/power/solar,
 /turf/open/floor/plasteel/airless/solarpanel,
@@ -37022,9 +36806,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wUI" = (
 /obj/machinery/light{
 	dir = 4
@@ -37062,9 +36844,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "wVu" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
@@ -37078,9 +36858,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wVF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -37088,9 +36866,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "wWc" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/machinery/light{
@@ -37108,9 +36884,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck1/starboard)
 "wWA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37166,6 +36940,14 @@
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"wYh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/nsv/bridge)
 "wYr" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer3{
 	dir = 5
@@ -37196,8 +36978,7 @@
 /area/science)
 "wZK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -37226,9 +37007,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "xaz" = (
-/obj/machinery/advanced_airlock_controller/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/advanced_airlock_controller/directional/north,
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
@@ -37241,9 +37020,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xaW" = (
 /obj/structure/table/glass,
 /turf/open/floor/plating{
@@ -37276,6 +37053,20 @@
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
 /area/nsv/briefingroom)
+"xbJ" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/frame1/central)
 "xcG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -37298,25 +37089,20 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/grid/techfloor,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "xej" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck1/frame2/central)
 "xfh" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 1;
-	icon_state = "morgue1"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/security/main)
@@ -37406,9 +37192,7 @@
 /obj/machinery/suit_storage_unit/pilot,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xgJ" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -37429,6 +37213,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/security/prison)
 "xhW" = (
@@ -37441,13 +37228,16 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/computer/atmos_control/tank/air_tank,
 /obj/effect/turf_decal/bot{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible/layer1{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/trinary/filter/flipped/on/layer3{
+	dir = 8;
+	filter_type = "o2"
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
@@ -37520,9 +37310,7 @@
 "xlG" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xlJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -37538,9 +37326,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xnf" = (
 /obj/machinery/button/door{
 	id = "fighterpod_airlock";
@@ -37549,9 +37335,7 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xng" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -37563,15 +37347,11 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "xnG" = (
 /obj/structure/reagent_dispensers/fueltank/aviation_fuel,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xnT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -37600,9 +37380,7 @@
 /area/maintenance/nsv/bridge)
 "xpe" = (
 /turf/closed/wall/steel,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "xpz" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -37725,9 +37503,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/grid/techfloor,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "xug" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/box,
@@ -37799,11 +37575,10 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger)
 "xvO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/security/detectives_office)
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/structure/closet/radiation,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck1/frame1/central)
 "xvQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -37829,17 +37604,14 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xxa" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Smoking lounge access";
 	req_one_access_txt = "12;25"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -37854,9 +37626,7 @@
 	pixel_y = 23
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xxX" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -37874,9 +37644,7 @@
 "xyN" = (
 /obj/structure/closet/secure_closet/hop,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "xzd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -37926,6 +37694,14 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/science)
+"xAD" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engineering)
 "xAL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -37940,9 +37716,7 @@
 	},
 /obj/machinery/light/runway,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xBg" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -38033,8 +37807,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/security/processing)
@@ -38049,9 +37822,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/overmap/fighter/light/prebuilt,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xGF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -38071,9 +37842,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "xHB" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -38083,13 +37852,11 @@
 	pixel_x = -32
 	},
 /turf/open/floor/carpet/blue,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "xHH" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Burn Mix -> Heat Exchanger"
+	name = "Burn Mix to Heat Exchanger"
 	},
 /obj/machinery/atmospherics/pipe/simple/brown/visible/layer1{
 	dir = 6
@@ -38118,11 +37885,13 @@
 /area/maintenance/nsv/deck1/port)
 "xIm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmos)
+"xIG" = (
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck1/frame3/central)
 "xIV" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/engine,
@@ -38139,20 +37908,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xJO" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = 26
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -38214,9 +37979,7 @@
 	},
 /obj/machinery/light/runway/delay3,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xLw" = (
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
@@ -38242,8 +38005,7 @@
 /area/engine/storage)
 "xLQ" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck1/frame2/central)
@@ -38341,13 +38103,10 @@
 "xME" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/monotile,
-/area/bridge{
-	name = "CIC"
-	})
+/area/bridge/cic)
 "xMZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/frame1/central)
@@ -38367,9 +38126,7 @@
 	},
 /obj/machinery/light/runway/delay5,
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xOo" = (
 /obj/machinery/light{
 	dir = 4
@@ -38455,6 +38212,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "xRV" = (
@@ -38469,9 +38229,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/grid/techfloor/grid,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "xSm" = (
 /obj/machinery/door/poddoor/ship/preopen{
 	dir = 4;
@@ -38479,9 +38237,7 @@
 	name = "Repressurization room"
 	},
 /turf/open/floor/monotile,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xSy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/ship/preopen{
@@ -38562,9 +38318,7 @@
 /area/maintenance/nsv/bridge)
 "xVP" = (
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "xWg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -38605,12 +38359,10 @@
 /area/ai_monitored/storage/eva)
 "xXA" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/grid/mono,
@@ -38624,9 +38376,7 @@
 /area/maintenance/nsv/bridge)
 "xYk" = (
 /turf/open/floor/plasteel/grid/techfloor,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "xYl" = (
 /turf/open/floor/monotile/dark,
 /area/security/checkpoint)
@@ -38646,6 +38396,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "xZh" = (
@@ -38659,6 +38410,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/monotile,
 /area/security/checkpoint)
@@ -38700,16 +38454,14 @@
 /area/science/robotics/mechbay)
 "yaK" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/security/prison)
 "ybW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics TEG";
@@ -38828,6 +38580,9 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/engine/engineering)
 "yfs" = (
@@ -38848,9 +38603,7 @@
 	apnw_id = "pegasusmain"
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/engine/engine_room/external{
-	name = "Armour Pumps"
-	})
+/area/engine/armour_pump)
 "ygm" = (
 /turf/open/openspace,
 /area/shuttle/turbolift/quaternary)
@@ -38866,12 +38619,19 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/hanger/notkmcstupidhanger)
 "yhB" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible/layer3{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer1{
+	name = "O2 to Stormdrive Fuel Flavouriser"
+	},
+/obj/machinery/firealarm{
+	pixel_x = 26;
+	pixel_y = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer3{
+	dir = 9
 	},
 /turf/open/floor/monotile,
 /area/engine/atmos)
@@ -38884,9 +38644,7 @@
 	},
 /obj/effect/landmark/nuclear_waste_spawner,
 /turf/open/floor/monotile,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "yhT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -38922,9 +38680,7 @@
 	id = "launch2"
 	},
 /turf/open/floor/plating,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "yjh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -38974,9 +38730,7 @@
 	req_one_access_txt = "69"
 	},
 /turf/open/floor/plasteel/ship,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 "ylj" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -38986,9 +38740,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/heads/hop{
-	name = "Executive officer's Office"
-	})
+/area/crew_quarters/heads/xo)
 "ymc" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -38997,9 +38749,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grid/steel,
-/area/nsv/hanger/notkmcstupidhanger/hangar{
-	name = "Squad Hangar Bay"
-	})
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar)
 
 (1,1,1) = {"
 kNW
@@ -53802,7 +53552,7 @@ fKz
 vCe
 xUD
 bjO
-bjO
+myd
 pFN
 isr
 tPP
@@ -54059,7 +53809,7 @@ mnf
 vCe
 bjO
 xUD
-xUD
+snr
 pFN
 bme
 lGh
@@ -54316,7 +54066,7 @@ bjV
 vCe
 uYC
 bjO
-xUD
+wFj
 pFN
 pFN
 pFN
@@ -56373,7 +56123,7 @@ urF
 kyt
 iiK
 rcA
-bYo
+aLh
 dzp
 wsd
 rzQ
@@ -58693,7 +58443,7 @@ acb
 acb
 acb
 acb
-bLB
+acb
 nXj
 tBU
 wkP
@@ -59200,7 +58950,7 @@ nlf
 eIa
 lrr
 hfV
-tnr
+pdQ
 aCi
 qbM
 kzl
@@ -59459,7 +59209,7 @@ aNT
 utj
 pdQ
 kER
-roI
+qbM
 sEL
 pmo
 kso
@@ -59963,7 +59713,7 @@ nKa
 kqm
 aPU
 trp
-pLr
+mmr
 fOi
 ibZ
 yfz
@@ -60185,7 +59935,7 @@ gzn
 kcT
 alP
 ccZ
-xLw
+hxm
 cmU
 ltV
 isc
@@ -60229,20 +59979,20 @@ lzH
 cau
 vCZ
 pdQ
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
 wfQ
 xvQ
 lhO
@@ -60486,7 +60236,7 @@ tDT
 dHG
 vCZ
 iXl
-dRH
+hkB
 qzw
 qzw
 qzw
@@ -60499,7 +60249,7 @@ mtV
 kpp
 muu
 dIn
-dRH
+hkB
 uun
 xlJ
 nWT
@@ -60554,8 +60304,8 @@ eQa
 qxN
 qxN
 qxN
-bFG
-wtf
+jEl
+cxX
 cxX
 fhP
 nLl
@@ -60743,7 +60493,7 @@ baa
 bGR
 bWO
 pdQ
-dRH
+hkB
 nyN
 wCL
 wCL
@@ -60756,7 +60506,7 @@ wxJ
 nbJ
 mgT
 eId
-dRH
+hkB
 cgr
 cIx
 mia
@@ -61000,7 +60750,7 @@ ogk
 uaJ
 pdQ
 gYu
-dRH
+hkB
 xxU
 wxJ
 wCL
@@ -61013,7 +60763,7 @@ vEy
 itT
 tgx
 xgB
-dRH
+hkB
 idj
 hEK
 efB
@@ -61257,7 +61007,7 @@ pLh
 sqR
 qnr
 nlf
-dRH
+hkB
 ueO
 dyW
 mnh
@@ -61270,7 +61020,7 @@ wxJ
 wxJ
 myl
 kZf
-dRH
+hkB
 krJ
 aSp
 pjT
@@ -61514,20 +61264,20 @@ eTn
 mJm
 gtz
 ksa
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
 hDq
 jls
 hDq
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
 odI
 stO
 kVB
 odI
-dRH
+hkB
 nUc
 whA
 hrB
@@ -61771,7 +61521,7 @@ uqO
 wyb
 pox
 rva
-dRH
+hkB
 fZT
 fZT
 fZT
@@ -62028,7 +61778,7 @@ wft
 gyP
 okU
 gfG
-dRH
+hkB
 fZT
 fZT
 fZT
@@ -62285,7 +62035,7 @@ uDc
 okU
 okU
 rva
-dRH
+hkB
 fZT
 btR
 fZT
@@ -62542,7 +62292,7 @@ gmO
 ioI
 ioI
 lBf
-dRH
+hkB
 fZT
 fZT
 fZT
@@ -62555,7 +62305,7 @@ dxd
 tTn
 nEP
 etW
-dRH
+hkB
 sZJ
 sZJ
 sZJ
@@ -62799,7 +62549,7 @@ dKW
 dKW
 dKW
 dKW
-dRH
+hkB
 fZT
 fZT
 fZT
@@ -63038,16 +62788,16 @@ rno
 mYb
 bct
 bct
-mIH
-mIH
+reo
+reo
 uWW
 wWe
-mIH
-mIH
+reo
+reo
 cQD
-mIH
-mIH
-mIH
+reo
+reo
+reo
 oIJ
 mIu
 jUV
@@ -63056,7 +62806,7 @@ hEL
 tHk
 bIf
 mCU
-dRH
+hkB
 fZT
 fZT
 fZT
@@ -63295,16 +63045,16 @@ bQc
 rno
 rno
 bct
-mIH
+reo
 wKT
-rdh
+lAD
 miW
-mIH
-jxQ
-jxQ
-svN
-jxQ
-mIH
+reo
+kpx
+kpx
+kWu
+kpx
+reo
 jvh
 mDT
 rrx
@@ -63313,15 +63063,15 @@ vLg
 xqs
 pPX
 jkp
-dRH
-dRH
+hkB
+hkB
 xSm
 xSm
 xSm
 xSm
 xSm
-dRH
-dRH
+hkB
+hkB
 paF
 wVF
 sFV
@@ -63552,16 +63302,16 @@ eUW
 eUW
 whG
 oOA
-mIH
-aCI
-jmj
+reo
+vCx
+dUx
 miW
-mIH
+reo
 nkB
-jxQ
+kpx
 nkB
-jxQ
-mIH
+kpx
+reo
 lwQ
 vOf
 pwr
@@ -63570,7 +63320,7 @@ wCr
 wCr
 wCr
 wCr
-dRH
+hkB
 xVP
 wxJ
 wxJ
@@ -63578,12 +63328,12 @@ wxJ
 wxJ
 wxJ
 xVP
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
 pbr
-dRH
-dRH
+hkB
+hkB
 sZJ
 sZJ
 kNW
@@ -63810,24 +63560,24 @@ eUW
 sOP
 olt
 flg
-aCI
+vCx
 uSR
 gAs
-mIH
-jxQ
-jxQ
-jxQ
-jxQ
-mIH
+reo
+kpx
+kpx
+kpx
+kpx
+reo
 nTN
-vOf
-rrx
+iMI
+wBO
 sFB
 ydJ
 ffk
 sDc
 dEy
-dRH
+hkB
 aMA
 aTV
 nui
@@ -63839,9 +63589,9 @@ oZt
 mFk
 xwx
 brX
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
 sZJ
 kNW
 kNW
@@ -64039,7 +63789,7 @@ qjc
 psH
 xvs
 vWf
-wsm
+hZW
 wsm
 hJp
 jHC
@@ -64066,16 +63816,16 @@ xME
 eUW
 hrl
 cHu
-mIH
-aCI
-aCI
+reo
+vCx
+vCx
 pHv
-mIH
+reo
 oEe
-jxQ
-jxQ
-jxQ
-mIH
+kpx
+kpx
+kpx
+reo
 njP
 vOf
 rrx
@@ -64084,7 +63834,7 @@ kLo
 xXz
 xXz
 oFR
-dRH
+hkB
 wOV
 rCr
 nui
@@ -64324,15 +64074,15 @@ eUW
 fwf
 pHo
 flg
-aCI
+vCx
 lWr
 hNh
-mIH
+reo
 ewR
-jxQ
+kpx
 nkB
-jxQ
-mIH
+kpx
+reo
 xXA
 mvq
 aGO
@@ -64341,7 +64091,7 @@ anZ
 pEm
 gbP
 dBO
-dRH
+hkB
 pVy
 neA
 nui
@@ -64353,9 +64103,9 @@ oZt
 tRy
 beQ
 eHO
-dRH
+hkB
 kEC
-dRH
+hkB
 sZJ
 kNW
 kNW
@@ -64380,7 +64130,7 @@ cWN
 jmz
 iZd
 tff
-baO
+tfx
 clX
 tfx
 nFd
@@ -64580,16 +64330,16 @@ eUW
 eUW
 kdu
 gIB
-mIH
-aCI
+reo
+vCx
 urG
 hCs
-mIH
-jxQ
-jxQ
-jxQ
-jxQ
-mIH
+reo
+kpx
+kpx
+kpx
+kpx
+reo
 njP
 emu
 mJz
@@ -64598,7 +64348,7 @@ cYY
 pEm
 uSa
 irv
-dRH
+hkB
 rvd
 qTO
 wxJ
@@ -64610,9 +64360,9 @@ oZt
 aBT
 clA
 brX
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
 sZJ
 sZJ
 sZJ
@@ -64835,18 +64585,18 @@ lyr
 mGe
 eHM
 rno
-rno
+tNL
 bct
-mIH
+reo
 urG
-jmj
+dUx
 gUD
-mIH
-jxQ
-jxQ
-jxQ
-jxQ
-mIH
+reo
+kpx
+kpx
+kpx
+kpx
+reo
 ibl
 pCW
 qKV
@@ -64855,21 +64605,21 @@ heb
 sQi
 sQi
 upL
-dRH
-dRH
+hkB
+hkB
 xSm
 xSm
 xSm
 xSm
 xSm
-dRH
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
+hkB
 pbr
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
 sZJ
 sZJ
 sZJ
@@ -65081,7 +64831,7 @@ sRc
 jxQ
 pCL
 mIH
-aCI
+mVx
 lDA
 aCI
 bct
@@ -65094,25 +64844,25 @@ bBf
 bQK
 jmK
 bct
-mIH
+reo
 iCL
 soZ
 hCs
-mIH
+reo
 nkB
-jxQ
+kpx
 nkB
-jxQ
-mIH
+kpx
+reo
 uRS
-vOf
-pwr
+iMI
+fls
 sFB
 ydJ
 fuX
 jYY
 srn
-dRH
+hkB
 xnf
 wxJ
 aSL
@@ -65126,10 +64876,10 @@ wxJ
 aCk
 uWF
 wxJ
-dRH
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
+hkB
 sZJ
 sZJ
 sZJ
@@ -65351,16 +65101,16 @@ dSE
 bct
 udm
 mNb
-mIH
+reo
 wKT
 tsr
 ppz
-mIH
-jxQ
-jxQ
-jxQ
-jxQ
-mIH
+reo
+kpx
+kpx
+kpx
+kpx
+reo
 njP
 vOf
 rrx
@@ -65369,7 +65119,7 @@ fWu
 fWu
 fWu
 fWu
-dRH
+hkB
 jry
 wxJ
 kAk
@@ -65386,9 +65136,9 @@ aSL
 gfh
 gfh
 vwy
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
 sZJ
 sZJ
 sZJ
@@ -65608,16 +65358,16 @@ xHB
 bct
 gYn
 jwj
-mIH
-mIH
+reo
+reo
 pkA
-mIH
-mIH
-mIH
-udl
-mIH
-mIH
-mIH
+reo
+reo
+reo
+tKq
+reo
+reo
+reo
 njP
 rjm
 kSi
@@ -65643,7 +65393,7 @@ kAk
 pbP
 mhJ
 wUx
-dRH
+hkB
 cxj
 sZJ
 sZJ
@@ -65849,8 +65599,8 @@ aaO
 iAe
 iik
 sJA
-sJA
-sJA
+brT
+uBJ
 beq
 osb
 jso
@@ -65870,10 +65620,10 @@ iAe
 lKe
 isc
 iAe
-gGl
+kxP
 iAe
-gGl
-gGl
+hKp
+gmC
 vum
 dbP
 uzx
@@ -65900,7 +65650,7 @@ iRv
 nrK
 nrK
 wQD
-dRH
+hkB
 cxj
 sZJ
 sZJ
@@ -66105,7 +65855,7 @@ fxu
 cAz
 iAe
 xng
-pQD
+mhq
 alm
 alm
 alm
@@ -66157,9 +65907,9 @@ wxJ
 wxJ
 wxJ
 wxJ
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
 sZJ
 gkh
 kZZ
@@ -66355,14 +66105,14 @@ aVv
 vPH
 cgR
 qrg
-qrg
+xvO
 dYU
 rrK
-cVd
-cAz
-iAe
-fph
-pQD
+kUc
+hqA
+roo
+gXe
+wYh
 alm
 tqk
 sIy
@@ -66396,8 +66146,8 @@ vum
 qtk
 pPH
 kji
-qtk
-dRH
+iKn
+hkB
 rjH
 wxJ
 kAk
@@ -66414,7 +66164,7 @@ aSL
 gfh
 gfh
 vwy
-dRH
+hkB
 cxj
 sZJ
 sZJ
@@ -66616,9 +66366,9 @@ lIa
 cmU
 wcp
 oAZ
-sMP
-iEc
-hxm
+cKT
+iAe
+iAe
 qbn
 alm
 ooI
@@ -66654,7 +66404,7 @@ swY
 swY
 aNC
 swY
-dRH
+hkB
 oJf
 wxJ
 kAk
@@ -66671,7 +66421,7 @@ kAk
 pbP
 mhJ
 hdi
-dRH
+hkB
 cxj
 sZJ
 sZJ
@@ -66873,10 +66623,10 @@ rpW
 mlw
 heu
 mDD
-cAz
+hGh
+ohg
 iAe
-quq
-pQD
+brR
 alm
 iwm
 shY
@@ -66901,9 +66651,9 @@ rkp
 rkp
 rkp
 uuK
-isc
-vum
-dtS
+vBU
+fPP
+kYF
 gKB
 rrx
 swY
@@ -66911,7 +66661,7 @@ mvs
 mvs
 kuZ
 mvs
-dRH
+hkB
 heh
 wxJ
 kAk
@@ -66928,9 +66678,9 @@ iRv
 nrK
 nrK
 wQD
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
 sZJ
 gkh
 kZZ
@@ -67130,10 +66880,10 @@ rpW
 cmU
 sVn
 cVd
-cAz
+wuY
+ojM
 iAe
 brR
-pQD
 alm
 bNU
 sNj
@@ -67158,9 +66908,9 @@ qkG
 qxv
 rkp
 uuK
-isc
-vum
-aaX
+vBU
+qSJ
+xIG
 gKB
 rrx
 swY
@@ -67168,7 +66918,7 @@ mvs
 pNh
 iJi
 usI
-dRH
+hkB
 krd
 wxJ
 kAk
@@ -67185,7 +66935,7 @@ vEy
 szc
 iFz
 wxJ
-dRH
+hkB
 cxj
 sZJ
 sZJ
@@ -67360,7 +67110,7 @@ kNW
 sZJ
 sZJ
 diW
-nNe
+bqQ
 dte
 cTr
 vdh
@@ -67385,12 +67135,12 @@ aIn
 lIa
 lIa
 efP
-aaO
-ovb
-aaO
+heu
+cVd
+wuY
+rYl
 iAe
 ljm
-isc
 alm
 laL
 sNj
@@ -67415,17 +67165,17 @@ tOO
 hAG
 rkp
 uuK
-isc
+vBU
 rnK
-dbP
-uJF
-dbP
+qLe
+sgf
+pFH
 swY
 swY
 swY
 aNC
 swY
-dRH
+hkB
 ymc
 wxJ
 kAk
@@ -67442,7 +67192,7 @@ aSL
 peJ
 sAm
 vwy
-dRH
+hkB
 cxj
 sZJ
 sZJ
@@ -67637,17 +67387,17 @@ elZ
 elZ
 elZ
 rVZ
-lzP
+iEc
 bbY
 tGB
 lzP
 gQu
 hEr
 aaY
-cAz
+wuY
+hwW
 iAe
 ljm
-vBU
 alm
 alm
 piU
@@ -67672,16 +67422,16 @@ rnN
 dSR
 rkp
 uuK
-isc
-vum
-njP
+vBU
+kcZ
+xIG
 hGp
 mJz
 jBJ
 lfW
 ocd
 qbt
-lfW
+voh
 nUm
 okn
 liM
@@ -67699,9 +67449,9 @@ kAk
 dKX
 nfk
 wUx
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
 sZJ
 gkh
 kZZ
@@ -67901,10 +67651,10 @@ woa
 xOT
 oma
 cVd
-cAz
+ekl
+uCW
 iAe
-wcF
-isc
+ljm
 alm
 uPb
 erF
@@ -67929,9 +67679,9 @@ kVl
 nQr
 rkp
 uuK
-isc
-vum
-xXA
+vBU
+vGZ
+iVq
 raf
 wBO
 upm
@@ -67956,7 +67706,7 @@ iRv
 efR
 pEJ
 wQD
-dRH
+hkB
 cxj
 sZJ
 sZJ
@@ -68160,8 +67910,8 @@ hmg
 cVd
 cKT
 iAe
-brR
-isc
+iAe
+ljm
 alm
 qap
 bjg
@@ -68186,7 +67936,7 @@ uyK
 sej
 rkp
 uuK
-uuK
+vBU
 vum
 scE
 gKB
@@ -68213,7 +67963,7 @@ bQk
 kou
 qti
 wxJ
-dRH
+hkB
 cxj
 sZJ
 sZJ
@@ -68411,14 +68161,14 @@ aVv
 ixV
 rpa
 qrg
-qrg
+xvO
 aWq
 eoh
 jWl
 cAz
 iAe
-ljm
-gGl
+isc
+wcF
 alm
 bHh
 mOZ
@@ -68439,11 +68189,11 @@ gMW
 gMW
 vHh
 nXo
-kea
+hxJ
 rkp
 rkp
 rkp
-iAe
+uuK
 fgR
 oIJ
 gKB
@@ -68452,8 +68202,8 @@ vum
 qtk
 pPH
 kji
-qtk
-dRH
+iKn
+hkB
 qsH
 wxJ
 kAk
@@ -68465,14 +68215,14 @@ aSL
 gfh
 gfh
 elV
-dRH
-dRH
+hkB
+hkB
 eBm
 qCQ
 oZt
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
 sZJ
 gkh
 kZZ
@@ -68674,8 +68424,8 @@ lHa
 hIG
 cAz
 iAe
-wcF
-pQD
+gGl
+brR
 xpe
 xpe
 kaX
@@ -68696,12 +68446,12 @@ gMW
 lHD
 pTy
 mVO
-viz
+hMv
 viz
 pKa
 rkp
 uuK
-vum
+prS
 njP
 gKB
 rrx
@@ -68710,7 +68460,7 @@ vum
 vum
 ahv
 vum
-dRH
+hkB
 dFY
 wxJ
 kAk
@@ -68722,14 +68472,14 @@ kAk
 pbP
 wpx
 hdm
-dRH
+hkB
 jUn
 tsM
 wOp
 gfh
 vwy
 tjx
-dRH
+hkB
 sZJ
 gkh
 kZZ
@@ -68931,8 +68681,8 @@ heu
 cVd
 cAz
 iAe
-wcF
-pQD
+gGl
+brR
 xpe
 hxe
 yhC
@@ -68949,8 +68699,8 @@ xqu
 kgs
 kgs
 wdN
-lio
-viz
+oyo
+dFG
 jyP
 rxh
 rAB
@@ -68960,14 +68710,14 @@ rkp
 uuK
 vum
 kni
-sgf
-qKV
+umj
+lUo
 vum
 mvs
 swY
 iUk
 usI
-dRH
+hkB
 rFA
 wxJ
 kAk
@@ -68979,14 +68729,14 @@ buC
 nrK
 nrK
 wQD
-dRH
+hkB
 lkh
 ndf
 eVY
 grS
 hdm
 tuB
-dRH
+hkB
 sZJ
 gkh
 kZZ
@@ -69184,12 +68934,12 @@ kNW
 kNW
 kNW
 vWf
-heu
-cVd
-cAz
-kYA
-brR
+aaO
+ovb
+aaO
+iAe
 pQD
+brR
 cyu
 pQx
 vRh
@@ -69224,7 +68974,7 @@ mvs
 swY
 iUk
 xUD
-dRH
+hkB
 kYT
 wxJ
 kAk
@@ -69232,18 +68982,18 @@ tHt
 hdm
 wxJ
 bOa
-dRH
-dRH
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
+hkB
+hkB
 tmT
 iRv
 nrK
 nrK
 wQD
 fJD
-dRH
+hkB
 sZJ
 gkh
 kZZ
@@ -69445,7 +69195,7 @@ heu
 cVd
 cAz
 iAe
-ljm
+isc
 plo
 xpe
 dHM
@@ -69481,7 +69231,7 @@ mvs
 swY
 rqk
 xUD
-dRH
+hkB
 fRe
 wxJ
 kAk
@@ -69500,7 +69250,7 @@ wCL
 wCL
 wCL
 dor
-dRH
+hkB
 sZJ
 gkh
 kZZ
@@ -69702,7 +69452,7 @@ lNi
 jWl
 cKT
 iAe
-cNd
+kbv
 isc
 xpe
 laZ
@@ -69738,7 +69488,7 @@ swY
 swY
 iUk
 usI
-dRH
+hkB
 olw
 wxJ
 kAk
@@ -69757,7 +69507,7 @@ wxJ
 wCL
 wxJ
 xnG
-dRH
+hkB
 sZJ
 gkh
 kZZ
@@ -69995,7 +69745,7 @@ usI
 xUD
 iJi
 fMU
-dRH
+hkB
 fRe
 wxJ
 kAk
@@ -70012,9 +69762,9 @@ wCL
 wxJ
 wCL
 wxJ
-snk
-dRH
-dRH
+wCL
+hkB
+hkB
 sZJ
 gkh
 gkh
@@ -70215,7 +69965,7 @@ fYV
 cqD
 rGF
 cAz
-iAe
+wci
 brR
 gGl
 xpe
@@ -70252,9 +70002,9 @@ usI
 pjB
 rqk
 usI
-dRH
+hkB
 ueF
-wxJ
+qYt
 iRv
 hpY
 jhC
@@ -70270,7 +70020,7 @@ dAm
 oJs
 uYe
 bLg
-dRH
+hkB
 sZJ
 sZJ
 sZJ
@@ -70509,32 +70259,32 @@ usI
 uYC
 rqk
 usI
-dRH
+hkB
 hkB
 rIh
-rIh
+pOY
 enw
-rIh
-rIh
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
+pOY
+pOY
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
 sZJ
 sZJ
 sZJ
@@ -70731,7 +70481,7 @@ cVd
 cAz
 iAe
 wcF
-pQD
+tzQ
 xpe
 eqF
 vRh
@@ -70766,9 +70516,9 @@ aOy
 geR
 rqk
 bjO
-dRH
+hkB
 auO
-wxJ
+dqC
 aSL
 qfq
 gfh
@@ -70988,7 +70738,7 @@ cVd
 cAz
 iAe
 ljm
-isc
+iLy
 xpe
 dMw
 vRh
@@ -71019,11 +70769,11 @@ njP
 gKB
 rrx
 vum
-xUD
-iPy
-iFm
-xUD
-dRH
+swY
+swY
+tsZ
+swY
+hkB
 cbK
 wxJ
 kAk
@@ -71245,7 +70995,7 @@ cVd
 cKT
 iAe
 ljm
-isc
+ucN
 xpe
 xyN
 mgj
@@ -71255,7 +71005,7 @@ oBV
 rQQ
 dlO
 oab
-tZd
+cMR
 tZd
 cRo
 bzh
@@ -71278,9 +71028,9 @@ pwr
 vum
 qqY
 wMq
-xUD
-usI
-dRH
+cdB
+jbU
+hkB
 olw
 wxJ
 kAk
@@ -71507,7 +71257,7 @@ pwy
 pwy
 rVs
 rVs
-gud
+wEd
 pwy
 rQQ
 rQQ
@@ -71533,36 +71283,36 @@ dbP
 uJF
 dbP
 vum
-iJi
-swY
-swY
-usI
-dRH
+baO
+oSH
+oSH
+jVH
+hkB
 nSI
 wxJ
 kAk
 jYt
 hdm
 dYR
-dRH
-dRH
+hkB
+hkB
 kBU
 kBU
 kBU
 kBU
-dRH
-dRH
+hkB
+hkB
 kBU
 kBU
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
 sZJ
 sZJ
 kNW
@@ -71790,24 +71540,24 @@ kYF
 gKB
 rrx
 vum
-rqk
-bjO
-swY
-usI
-dRH
+iPy
+oSH
+nzh
+quD
+hkB
 cbK
 wxJ
 kAk
 jYt
 hdm
 wxJ
-dRH
+hkB
 abD
 qRN
 oMc
 drN
 qzG
-dRH
+hkB
 jyD
 nHY
 nyw
@@ -72007,11 +71757,11 @@ tRs
 xLw
 jOs
 lqW
-aZs
+tnr
 iWT
-iDu
+jqF
 fBI
-cqD
+xbJ
 cwh
 fDK
 grI
@@ -72034,27 +71784,27 @@ pGV
 fHQ
 kpc
 sZR
-asf
-asf
+rAD
+rAD
 cgM
-asf
-asf
-asf
-oeC
-asf
+rAD
+rAD
+rAD
+mSd
+rAD
 vFN
 hAz
 lMk
-rrx
+asf
 uXE
-rqk
-bjO
-swY
-usI
-dRH
+oeC
+ezJ
+fJY
+rlm
+hkB
 cbK
 wxJ
-kAk
+taQ
 xJr
 uxS
 ihh
@@ -72304,18 +72054,18 @@ hMO
 sgf
 wGa
 vum
-kuZ
-swY
-swY
-usI
-dRH
+enf
+oSH
+oSH
+jUG
+hkB
 dtR
 wxJ
-kAk
+taQ
 rcx
 cVD
-ihh
-dTs
+nvh
+hkB
 mIh
 rDc
 tcy
@@ -72520,7 +72270,7 @@ cmU
 xLw
 dhS
 lIa
-pkL
+kYA
 ycv
 lIa
 rpW
@@ -72561,36 +72311,36 @@ hlt
 gKB
 pwr
 vum
-rqk
-bjO
-usI
-usI
-dRH
+rfl
+rRU
+pMK
+cJA
+hkB
 nSI
 wxJ
 kAk
 mDJ
 hdm
 seJ
-dRH
-dRH
+hkB
+hkB
 kBU
 kBU
 kBU
 kBU
-dRH
-dRH
+hkB
+hkB
 kBU
 kBU
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
 sZJ
 sZJ
 kNW
@@ -72818,15 +72568,15 @@ swY
 qyL
 swY
 swY
-iJi
+nRy
 swY
 swY
 swY
-dRH
+hkB
 olw
 wxJ
 kAk
-rcx
+tAZ
 mrZ
 gfh
 fwk
@@ -73034,7 +72784,7 @@ cmU
 tRs
 xpz
 lIa
-kGp
+lfF
 jhh
 lIa
 rpW
@@ -73075,11 +72825,11 @@ xUD
 xgi
 vEO
 usI
-rqk
-bjO
-bjO
-usI
-dRH
+hcy
+myd
+iht
+oxp
+hkB
 cbK
 wxJ
 lOj
@@ -73309,7 +73059,7 @@ dEe
 dvW
 klf
 hYb
-raC
+uRh
 xQo
 msH
 pbl
@@ -73333,10 +73083,10 @@ eqS
 bCP
 gDN
 dTA
-uFA
+rjs
 iZp
 hVf
-dRH
+hkB
 tQR
 wxJ
 kAk
@@ -73592,33 +73342,33 @@ cjC
 fCt
 cjC
 fGp
-ifw
-dRH
+vHG
+hkB
 nSI
 wxJ
 kAk
 mDJ
 hdm
 dYR
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
-dRH
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
+hkB
 sZJ
 sZJ
 kNW
@@ -73805,7 +73555,7 @@ cmU
 pfo
 uGm
 lIa
-pkL
+quq
 ioM
 tRs
 lIa
@@ -73824,7 +73574,7 @@ ksS
 uhG
 hYb
 raC
-bQf
+sDN
 msH
 pbl
 tjA
@@ -73849,7 +73599,7 @@ mvs
 mvs
 cjC
 nOw
-kvr
+dmE
 cjC
 oLu
 cjC
@@ -73857,7 +73607,7 @@ cjC
 sgC
 cjC
 cjC
-dRH
+hkB
 knx
 knx
 knx
@@ -74107,10 +73857,10 @@ mvs
 cjC
 pik
 rdz
-uFA
+rjs
 gGd
-gDN
-gDN
+aRK
+aRK
 bXN
 tNA
 cjC
@@ -74319,7 +74069,7 @@ cmU
 jOs
 cmU
 lIa
-mLo
+roI
 lIa
 lIa
 lIa
@@ -74573,7 +74323,7 @@ fuA
 xDv
 gVT
 wuA
-pfo
+eAB
 iEi
 lIa
 uqr
@@ -75087,8 +74837,8 @@ fuA
 xDv
 vSq
 cdK
-wuA
-dhS
+gsu
+hxm
 lIa
 xLw
 qjL
@@ -75342,7 +75092,7 @@ jHO
 pkM
 fuA
 xDv
-ycv
+bLB
 cmU
 cmU
 cmU
@@ -75599,7 +75349,7 @@ jHO
 pkM
 fuA
 xDv
-mhk
+bVu
 cmU
 iEi
 iEi
@@ -75607,10 +75357,10 @@ lIa
 lIa
 qjL
 sHV
-bqQ
+fNf
 uoC
 oye
-hZW
+bxF
 shO
 sgK
 omb
@@ -75856,7 +75606,7 @@ dWU
 eKT
 mKw
 xDv
-ycv
+cCW
 jOs
 xLw
 pfo
@@ -75864,7 +75614,7 @@ lIa
 rpW
 qjL
 bhc
-xvO
+fNf
 rVe
 duO
 bxF
@@ -76113,7 +75863,7 @@ lJk
 pkM
 fuA
 xDv
-mhk
+bVu
 cmU
 xpz
 lIa
@@ -76121,7 +75871,7 @@ lIa
 gba
 qjL
 qax
-xvO
+fNf
 qEX
 pPV
 rxb
@@ -76378,7 +76128,7 @@ rpW
 rpW
 qjL
 ntZ
-rQS
+fNf
 fNf
 gJr
 qjL
@@ -76627,7 +76377,7 @@ jHO
 xlU
 wAR
 xDv
-mhk
+bVu
 iEi
 lIa
 rpW
@@ -77141,12 +76891,12 @@ jHO
 xlU
 fuA
 xDv
-tRs
+dtS
 cwl
 xYT
 kxC
 iBx
-wuA
+rQS
 qjL
 qjL
 qjL
@@ -77660,7 +77410,7 @@ lIa
 lIa
 lIa
 raO
-wuA
+sMP
 lIa
 lIa
 lIa
@@ -77669,9 +77419,9 @@ qcS
 kZt
 vZR
 jnJ
-tCV
-aWe
-bKF
+kfy
+gkN
+vMq
 oWq
 vuC
 bTT
@@ -78176,16 +77926,16 @@ lIa
 hvY
 eGz
 wrr
-eGz
-gzn
-gzn
-ccZ
+wtf
+dAx
+dAx
+hdu
 qjL
 mXP
 jRP
 hZZ
 qjL
-bKF
+sjs
 otN
 wXD
 iJa
@@ -78983,7 +78733,7 @@ xnx
 xnx
 wir
 jcI
-pei
+dIA
 hHS
 vlX
 gRA
@@ -79497,7 +79247,7 @@ xSl
 yfC
 hsM
 jcI
-pei
+dIA
 hHS
 vlX
 oKJ
@@ -80011,7 +79761,7 @@ qrQ
 xYk
 hsM
 kQa
-pei
+dIA
 hHS
 vlX
 aoo
@@ -80268,7 +80018,7 @@ iUI
 rVE
 hsM
 gZs
-pei
+dIA
 hHS
 vlX
 vlX
@@ -80531,9 +80281,9 @@ oYH
 xUD
 xUD
 cjC
-xUD
-xUD
-bjO
+snr
+wFj
+myd
 cjC
 cjC
 usI
@@ -81039,7 +80789,7 @@ bcj
 cSP
 pNc
 gZs
-pei
+dIA
 hHS
 oYH
 xUD
@@ -81553,9 +81303,9 @@ tid
 iZs
 ahO
 sHe
-pei
+dIA
 hHS
-amw
+xAD
 rBc
 qGm
 aKd
@@ -82551,7 +82301,7 @@ ueK
 lVn
 hrn
 rxI
-eAB
+rAd
 eSz
 lmU
 vux
@@ -84354,8 +84104,8 @@ pmD
 pmD
 pmD
 tkI
-eMU
-adS
+azt
+jkL
 lNd
 qOv
 dGf
@@ -85157,7 +84907,7 @@ hWO
 hXK
 aHE
 lds
-rUZ
+fpj
 rUZ
 aHE
 cjC
@@ -85680,8 +85430,8 @@ jJr
 pbi
 owL
 usI
-bVu
-lfF
+usI
+cjC
 nRR
 afz
 djQ
@@ -87971,7 +87721,7 @@ dSH
 dSH
 hUf
 dSH
-dSH
+hUk
 nkX
 peR
 mvb
@@ -88221,11 +87971,11 @@ oKS
 fHG
 fHG
 fHG
-fHG
+nBt
 gxu
 hrr
 eUb
-gsu
+gXv
 ncQ
 gXv
 mZX
@@ -88241,7 +87991,7 @@ pOS
 kne
 aZU
 nXl
-tRV
+mIS
 fHG
 cjC
 cjC
@@ -88481,7 +88231,7 @@ bJo
 hBE
 tZR
 xhY
-cCW
+nXl
 tgU
 qDL
 aAH
@@ -90042,7 +89792,7 @@ fHG
 kwF
 fHG
 fHG
-nyc
+nmY
 usI
 usI
 usI

--- a/_maps/map_files/Pegasus/pegasus2.dmm
+++ b/_maps/map_files/Pegasus/pegasus2.dmm
@@ -12,8 +12,7 @@
 /obj/structure/rack,
 /obj/item/storage/box/monkeycubes,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/medical/virology)
@@ -152,8 +151,7 @@
 "adU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/stripes/white/corner{
-	dir = 4;
-	icon_state = "warninglinecorner_white"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/kitchen)
@@ -200,9 +198,32 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile/dark,
 /area/quartermaster/office)
+"ahO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "gaussgang";
+	name = "public gauss access shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "aiS" = (
 /turf/closed/wall/r_wall,
 /area/quartermaster/storage)
+"ajF" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile,
+/area/medical/medbay/lobby)
 "ajR" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 4
@@ -236,9 +257,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "akW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -261,9 +280,7 @@
 	dir = 9
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "alw" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -319,6 +336,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
+"amj" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/frame3/central)
 "amP" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -365,12 +390,10 @@
 	})
 "aom" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -424,9 +447,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/light_switch/west,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "aqW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -437,9 +458,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "att" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/monotile,
@@ -481,8 +500,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -496,9 +514,7 @@
 "auU" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "auX" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -607,13 +623,13 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "axV" = (
 /obj/structure/cable{
 	icon_state = "5-8"
@@ -682,8 +698,7 @@
 /area/quartermaster/storage)
 "aAC" = (
 /obj/structure/chair/pew/left{
-	dir = 8;
-	icon_state = "pewend_left"
+	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -707,12 +722,10 @@
 /area/engine/atmospherics_engine)
 "aAS" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -737,9 +750,7 @@
 	},
 /obj/structure/table,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "aBc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -853,8 +864,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "aEI" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -893,14 +903,10 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "aGU" = (
 /turf/closed/wall/steel,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "aIr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -954,8 +960,7 @@
 /area/crew_quarters/kitchen/coldroom)
 "aJz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/theatre)
@@ -968,20 +973,15 @@
 "aJQ" = (
 /obj/structure/ship_weapon/railgun_assembly{
 	bound_height = 32;
-	dir = 4;
-	icon_state = "railgun_platform"
+	dir = 4
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "aJT" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "aKv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1017,9 +1017,7 @@
 	req_access_txt = "46"
 	},
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "aLn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -1041,12 +1039,10 @@
 /area/engine/atmospherics_engine)
 "aNj" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
@@ -1156,8 +1152,7 @@
 "aQC" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -1210,9 +1205,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/grid/lino,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "aST" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/template_noop,
@@ -1229,8 +1222,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/lobby)
@@ -1257,9 +1249,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "aTr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -1267,6 +1257,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "aTw" = (
@@ -1334,9 +1325,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "aVa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
@@ -1453,10 +1442,10 @@
 "aYD" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "aYQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1477,8 +1466,7 @@
 /area/quartermaster/storage)
 "aZQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -1486,16 +1474,14 @@
 "bam" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "baB" = (
 /obj/machinery/clonepod/prefilled,
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/medical/genetics)
@@ -1531,8 +1517,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -1609,9 +1594,7 @@
 /area/library)
 "bex" = (
 /turf/open/indestructible/sound/pool,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "bfH" = (
 /obj/structure/table/reinforced,
 /obj/item/ship_weapon/parts/torpedo/warhead,
@@ -1630,12 +1613,10 @@
 /area/nsv/weapons/fore)
 "bfO" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grid/mono,
@@ -1649,8 +1630,7 @@
 "bgJ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 4;
-	icon_state = "pipe-t"
+	dir = 4
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -1670,9 +1650,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "bgU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1681,8 +1659,7 @@
 /area/nsv/weapons/fore)
 "bhv" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame2/central)
@@ -1698,8 +1675,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -1718,6 +1694,11 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/hallway/secondary/exit/departure_lounge)
+"bhW" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/port)
 "biD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -1736,27 +1717,23 @@
 /area/nsv/crew_quarters/heads/maa)
 "bjp" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame3/central)
 "bju" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame3/central)
 "bjw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/quartermaster/storage)
@@ -1804,15 +1781,13 @@
 /area/maintenance/nsv/deck2/starboard)
 "blQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/carpet/ship,
 /area/medical/virology)
 "bmU" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -1822,12 +1797,10 @@
 "bnk" = (
 /obj/machinery/door/airlock/ship/medical,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/medical/medbay/lobby)
@@ -1841,9 +1814,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
 "bnF" = (
@@ -1852,8 +1823,7 @@
 	pixel_x = -23
 	},
 /obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "cryopod-open"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/cryopods)
@@ -1948,6 +1918,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/monotile,
 /area/quartermaster/sorting)
 "brT" = (
@@ -1980,8 +1953,7 @@
 /area/quartermaster/warehouse)
 "bso" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2004,14 +1976,11 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "bta" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
@@ -2020,7 +1989,6 @@
 "btn" = (
 /obj/structure/fluff/paper{
 	dir = 8;
-	icon_state = "paper";
 	name = "undelivered letters"
 	},
 /obj/machinery/light/small{
@@ -2109,9 +2077,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "bvi" = (
 /turf/open/floor/carpet/ship,
 /area/medical/virology)
@@ -2122,9 +2088,7 @@
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "bvB" = (
 /obj/structure/table/reinforced,
 /obj/item/grenade/chem_grenade,
@@ -2146,6 +2110,10 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
+"bvI" = (
+/obj/item/beacon,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "bwj" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "puceGANG"
@@ -2163,8 +2131,7 @@
 "bwO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
@@ -2179,13 +2146,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "bxn" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -2249,9 +2216,7 @@
 "bAl" = (
 /obj/structure/chair/stool,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "bAw" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plasteel/chapel{
@@ -2261,8 +2226,7 @@
 "bAx" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -2276,12 +2240,10 @@
 /area/maintenance/nsv/deck2/port)
 "bBi" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/grid/mono,
@@ -2306,8 +2268,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "bCa" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
@@ -2352,9 +2313,10 @@
 "bDJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
+"bDP" = (
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "bEa" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -2364,13 +2326,10 @@
 /area/maintenance/nsv/deck2/starboard)
 "bFt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "bFR" = (
 /obj/structure/cable{
 	icon_state = "4-9"
@@ -2388,7 +2347,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/sign/ship/smoking{
 	dir = 4;
-	icon_state = "smoking";
 	pixel_x = -32
 	},
 /turf/open/floor/carpet/ship/beige_carpet,
@@ -2429,10 +2387,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "bJu" = (
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet/east,
@@ -2460,9 +2419,7 @@
 /obj/machinery/ship_weapon/torpedo_launcher/west,
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "bLn" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -2475,9 +2432,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "bLw" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2603,8 +2558,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -2617,6 +2571,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
+"bRq" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "chem_privacy";
+	name = "privacy shutters"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/medical/medbay/lobby)
 "bRC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 1
@@ -2631,12 +2594,10 @@
 /area/medical/medbay/lobby)
 "bSb" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2645,12 +2606,10 @@
 /area/hallway/nsv/deck2/frame3/central)
 "bSJ" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -2685,6 +2644,7 @@
 "bTL" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/purple,
 /area/library)
 "bTS" = (
@@ -2724,17 +2684,14 @@
 /obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/kitchen)
 "bXG" = (
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "bXM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2774,13 +2731,16 @@
 "bYW" = (
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
+"bZr" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/monotile,
+/area/nsv/weapons/gauss/battery/deck2/port)
 "cam" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/morgue)
@@ -2824,9 +2784,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "ccn" = (
 /obj/structure/extinguisher_cabinet/north,
 /obj/structure/disposalpipe/segment{
@@ -2836,8 +2794,7 @@
 /area/library)
 "cct" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/status_display/shuttle/north,
@@ -2853,8 +2810,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "cdR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
@@ -2882,13 +2838,10 @@
 /area/maintenance/nsv/deck2/starboard)
 "ceB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "ceR" = (
 /obj/machinery/holopad,
 /turf/open/floor/monotile/dark,
@@ -2898,9 +2851,6 @@
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
 "cfv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating{
@@ -2974,8 +2924,7 @@
 "cjc" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -2997,16 +2946,15 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "ckz" = (
 /obj/structure/frame/machine/ship_weapon/pdc_mount,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "ckH" = (
 /obj/structure/cable/green{
 	icon_state = "4-10"
@@ -3081,13 +3029,10 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/effect/turf_decal/tile/ship/full/red,
 /obj/machinery/camera/autoname{
-	dir = 9;
-	icon_state = "camera"
+	dir = 9
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "cor" = (
 /obj/effect/turf_decal/tile/ship/half/red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -3106,6 +3051,14 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/quartermaster/office)
+"coQ" = (
+/obj/machinery/door/airlock/highsecurity/ship{
+	name = "Weapons Bay";
+	req_one_access_txt = "69"
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "cpk" = (
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Weapons Bay";
@@ -3113,8 +3066,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3208,14 +3160,16 @@
 /area/maintenance/nsv/deck2/port)
 "crJ" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/nsv/deck2/starboard)
 "csr" = (
 /obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "cryopod-open"
+	dir = 4
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/monotile/dark,
@@ -3282,9 +3236,14 @@
 /turf/open/floor/monotile,
 /area/hydroponics)
 "cwm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/closed/wall/r_wall,
-/area/engine/atmospherics_engine)
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/monotile/dark,
+/area/quartermaster/storage)
 "cwG" = (
 /turf/closed/wall/r_wall,
 /area/hallway/nsv/deck2/frame3/central)
@@ -3315,9 +3274,7 @@
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "cyM" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/cable{
@@ -3327,9 +3284,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "cyV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3406,9 +3361,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "cCp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3435,12 +3388,10 @@
 /area/quartermaster/sorting)
 "cCH" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -3448,11 +3399,9 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame3/central)
 "cDc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmospherics_engine)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/turf/open/floor/wood,
+/area/maintenance/nsv/deck2/port)
 "cDD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3493,8 +3442,7 @@
 /area/medical/chemistry)
 "cFC" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -3502,8 +3450,7 @@
 /area/medical/medbay)
 "cFN" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/structure/cable{
@@ -3528,8 +3475,7 @@
 "cGu" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -3554,9 +3500,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "cHD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3592,6 +3536,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "cKC" = (
@@ -3599,9 +3544,7 @@
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "cKE" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -3668,7 +3611,6 @@
 "cLF" = (
 /obj/structure/fluff/paper{
 	dir = 10;
-	icon_state = "paper";
 	name = "undelivered letters"
 	},
 /obj/item/destTagger{
@@ -3705,10 +3647,12 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -11
+	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "cLS" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /turf/open/floor/plating,
@@ -3751,8 +3695,7 @@
 "cMF" = (
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
@@ -3777,9 +3720,7 @@
 	name = "Radiation Bunker"
 	})
 "cMT" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -3788,9 +3729,7 @@
 "cNN" = (
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "cNR" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/effect/turf_decal/box,
@@ -3824,8 +3763,7 @@
 /area/hydroponics)
 "cQo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/item/radio/intercom/directional/west,
@@ -3844,6 +3782,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/medical/surgery)
+"cQv" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/medical/chemistry)
 "cQO" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -3947,9 +3889,7 @@
 	},
 /obj/machinery/light_switch/east,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "cWz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3989,8 +3929,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -4003,9 +3942,7 @@
 /obj/structure/table/reinforced,
 /obj/item/coin/arcade_token,
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "cXw" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/monotile,
@@ -4053,9 +3990,7 @@
 "dbk" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dbx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -4074,8 +4009,7 @@
 /area/crew_quarters/theatre)
 "ddJ" = (
 /obj/structure/chair/pew/right{
-	dir = 8;
-	icon_state = "pewend_right"
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
@@ -4103,9 +4037,7 @@
 	pixel_y = 23
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "deK" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating{
@@ -4153,12 +4085,10 @@
 	name = "Crew Quarters"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4221,8 +4151,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "diO" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
@@ -4239,11 +4168,9 @@
 	},
 /area/maintenance/nsv/deck2/port)
 "djo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 9
-	},
-/turf/closed/wall/steel,
-/area/maintenance/nsv/deck2/starboard)
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "djB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4303,13 +4230,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
 /area/janitor)
+"dlh" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/monotile,
+/area/medical/medbay)
 "dlq" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/lawoffice)
@@ -4400,9 +4337,7 @@
 	dir = 9
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dpF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4441,6 +4376,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -4460,17 +4396,13 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dsc" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/light,
 /turf/open/floor/monotile,
@@ -4478,7 +4410,6 @@
 "dse" = (
 /obj/machinery/door/window/northright{
 	base_state = "left";
-	dir = 1;
 	icon_state = "left";
 	name = "Library Desk Door";
 	req_access_txt = "37"
@@ -4491,9 +4422,7 @@
 	dir = 5
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "dsy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4506,12 +4435,10 @@
 "dsR" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/mono,
@@ -4521,9 +4448,7 @@
 /obj/effect/turf_decal/stripes/white/line,
 /obj/machinery/light_switch/west,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dtf" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -4540,6 +4465,22 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/quartermaster/office)
+"duo" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "duw" = (
 /obj/structure/bookcase/manuals/medical,
 /turf/open/floor/wood,
@@ -4574,8 +4515,7 @@
 "dxa" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4593,20 +4533,21 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
+	dir = 6
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
 "dyW" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/maintenance/nsv/deck2/port)
@@ -4644,9 +4585,7 @@
 "dAd" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dAO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera/autoname,
@@ -4724,9 +4663,7 @@
 	pixel_x = -22
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "dDL" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4737,8 +4674,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "dEn" = (
 /obj/structure/chair/sofa/right{
-	dir = 8;
-	icon_state = "sofaend_right"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -4810,6 +4746,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"dHg" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/nsv/deck2/starboard)
 "dHr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -4837,17 +4779,13 @@
 	dir = 6
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "dIK" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/fire,
@@ -4879,6 +4817,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
+"dKm" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/nsv/deck2/port)
 "dKC" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -4897,12 +4841,10 @@
 /area/maintenance/department/medical)
 "dLf" = (
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/airlock/ship/medical{
 	name = "Accident And Emergency"
@@ -4959,8 +4901,7 @@
 /obj/machinery/door/window/eastright{
 	base_state = "left";
 	icon_state = "left";
-	name = "Danger: Conveyor Access";
-	req_access_txt = "0"
+	name = "Danger: Conveyor Access"
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
@@ -4970,26 +4911,20 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dMX" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/matches{
 	pixel_y = 5
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dNb" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5046,9 +4981,7 @@
 "dOL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dPd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -5090,9 +5023,7 @@
 /obj/item/vending_refill/cigarette,
 /obj/machinery/light_switch/west,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dPM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -5107,8 +5038,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5135,8 +5065,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/quartermaster/sorting)
@@ -5166,15 +5095,11 @@
 	sortType = 20
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dUN" = (
 /obj/machinery/light,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dVl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -5184,12 +5109,10 @@
 "dVt" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment{
@@ -5200,9 +5123,7 @@
 "dVv" = (
 /obj/structure/sign/logo,
 /turf/closed/wall/steel,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dVW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5266,9 +5187,7 @@
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/camera/autoname,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "dYb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -5285,12 +5204,10 @@
 /area/maintenance/nsv/deck2/port)
 "dYX" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/camera/autoname,
@@ -5311,12 +5228,10 @@
 /area/security/checkpoint/supply)
 "eaE" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/grid/mono,
@@ -5407,9 +5322,7 @@
 	dir = 1
 	},
 /turf/closed/wall/steel,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "edS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -5418,17 +5331,17 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "edW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "2-5"
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/nsv/deck2/starboard)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
+/turf/open/floor/wood,
+/area/maintenance/nsv/deck2/port)
 "eec" = (
 /obj/structure/sign/ship/nosmoking,
 /turf/closed/wall/steel,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "eeU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -5453,8 +5366,7 @@
 /area/janitor)
 "efE" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/item/ship_weapon/ammunition/torpedo/nuke,
 /obj/item/ship_weapon/ammunition/torpedo/nuke{
@@ -5470,9 +5382,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "efH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -5495,16 +5405,29 @@
 "efW" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/frame3/central)
+"efY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame3/central)
 "ege" = (
 /obj/structure/cable{
@@ -5514,10 +5437,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "egI" = (
 /obj/structure/fluff/broken_flooring,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -5542,8 +5466,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "eig" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/janitor)
@@ -5553,9 +5476,7 @@
 	},
 /obj/effect/turf_decal/tile/ship/full/blue,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "eiH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5569,9 +5490,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "eiM" = (
 /obj/structure/table/reinforced,
 /obj/item/poster/random_official,
@@ -5579,6 +5498,14 @@
 /obj/item/poster/random_official,
 /turf/open/floor/carpet,
 /area/lawoffice)
+"eiS" = (
+/obj/machinery/gauss_dispenser,
+/obj/effect/turf_decal/loading_area,
+/obj/structure/closet/crate{
+	name = "railgun projectile crate"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "ejx" = (
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/wood,
@@ -5672,9 +5599,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "enD" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -5738,6 +5663,12 @@
 "erR" = (
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"erT" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck2/port)
 "erW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -5782,9 +5713,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "etx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5801,17 +5730,17 @@
 	dir = 9
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "etZ" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame3/central)
 "eul" = (
@@ -5859,16 +5788,14 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "evD" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -5955,9 +5882,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "exO" = (
 /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
 /obj/item/ship_weapon/ammunition/torpedo/torpedo_casing,
@@ -5968,8 +5893,7 @@
 /area/nsv/weapons/fore)
 "eyE" = (
 /obj/structure/chair/pew/left{
-	dir = 8;
-	icon_state = "pewend_left"
+	dir = 8
 	},
 /obj/structure/noticeboard{
 	pixel_y = 29
@@ -5986,6 +5910,9 @@
 /obj/item/stack/sheet/cardboard,
 /obj/item/stack/rods/fifty,
 /obj/item/storage/box/lights/mixed,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "eyL" = (
@@ -6005,15 +5932,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen/coldroom)
 "ezT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/janitor)
@@ -6048,13 +5973,10 @@
 	pixel_y = 26
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "eEm" = (
 /obj/structure/chair/pew{
-	dir = 8;
-	icon_state = "pewmiddle"
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
@@ -6071,8 +5993,7 @@
 /area/medical/genetics)
 "eER" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -6088,9 +6009,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "eGx" = (
 /turf/closed/wall/steel,
 /area/medical)
@@ -6148,12 +6067,10 @@
 /area/chapel/main)
 "eIq" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	c_tag = "FTL engine"
@@ -6163,8 +6080,7 @@
 /area/hallway/nsv/deck2/frame3/central)
 "eIy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/noslip/dark,
 /area/maintenance/port{
@@ -6183,9 +6099,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "eIX" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -6203,8 +6117,7 @@
 /area/chapel/main)
 "eJV" = (
 /obj/machinery/sleeper{
-	dir = 1;
-	icon_state = "sleeper"
+	dir = 1
 	},
 /obj/machinery/light,
 /turf/open/floor/monotile/dark,
@@ -6221,13 +6134,11 @@
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/ladder,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "eLb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
@@ -6236,9 +6147,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "eLr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -6260,9 +6169,7 @@
 	pixel_x = -22
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "eLI" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -6298,9 +6205,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "eMd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -6314,12 +6219,10 @@
 /area/quartermaster/office)
 "eMQ" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/grid/mono,
@@ -6368,20 +6271,24 @@
 "ePA" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/medical/cryo)
+"ePP" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "eQn" = (
 /obj/structure/sign/logo{
 	icon_state = "nanotrasen_sign2"
 	},
 /turf/closed/wall/steel,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "eRn" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/tile/neutral,
@@ -6405,14 +6312,11 @@
 /area/maintenance/nsv/deck2/starboard)
 "eUK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "eUL" = (
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/table/glass,
@@ -6424,11 +6328,13 @@
 "eVf" = (
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
@@ -6456,9 +6362,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "eWn" = (
 /obj/machinery/light{
 	dir = 4
@@ -6472,10 +6376,10 @@
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
 "eWL" = (
-/obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/monotile,
 /area/quartermaster/office)
 "eXj" = (
@@ -6508,13 +6412,12 @@
 /turf/open/floor/wood,
 /area/library)
 "fay" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/closed/wall/steel,
 /area/maintenance/nsv/deck2/starboard)
 "faI" = (
 /obj/structure/fluff/paper{
 	dir = 9;
-	icon_state = "paper";
 	name = "undelivered letters"
 	},
 /obj/structure/disposalpipe/trunk{
@@ -6525,8 +6428,7 @@
 	},
 /obj/machinery/door/window/eastleft{
 	dir = 2;
-	name = "Mail Delivery";
-	req_access_txt = "0"
+	name = "Mail Delivery"
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -6568,9 +6470,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "fdf" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
@@ -6606,9 +6506,9 @@
 "fdJ" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame1/central)
 "feo" = (
@@ -6622,8 +6522,7 @@
 /area/quartermaster/storage)
 "fes" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
@@ -6676,9 +6575,7 @@
 	},
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "fgJ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -6786,19 +6683,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "fkP" = (
-/obj/machinery/computer/cloning{
-	dir = 4;
-	icon_state = "computer"
-	},
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/north,
+/obj/machinery/dna_scannernew,
 /turf/open/floor/engine,
 /area/medical/genetics)
 "flE" = (
@@ -6821,10 +6712,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "fnH" = (
 /obj/effect/spawner/room/tenxfive,
 /turf/template_noop,
@@ -6985,9 +6877,7 @@
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "ftj" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -7034,6 +6924,7 @@
 "fvh" = (
 /obj/machinery/smartfridge/drying_rack,
 /obj/machinery/computer/ship/viewscreen,
+/obj/machinery/camera/autoname,
 /turf/open/floor/wood,
 /area/hydroponics)
 "fvO" = (
@@ -7097,12 +6988,10 @@
 /area/janitor)
 "fxA" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7119,8 +7008,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "fxP" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -7169,9 +7057,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "fAQ" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/stripes/white/line{
@@ -7214,6 +7100,9 @@
 /area/maintenance/nsv/deck2/port)
 "fDG" = (
 /obj/structure/extinguisher_cabinet/south,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "fDO" = (
@@ -7222,13 +7111,20 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/techmaint,
 /area/janitor)
+"fDR" = (
+/obj/machinery/button/door{
+	id = "gaussgang";
+	name = "public gauss access";
+	req_one_access_txt = "69"
+	},
+/turf/closed/wall/steel,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "fEm" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Library"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -7257,8 +7153,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "fFq" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7272,6 +7167,14 @@
 /obj/machinery/mineral/ore_redemption,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
+"fHc" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/item/beacon,
+/turf/open/floor/monotile/dark,
+/area/medical/medbay/lobby)
 "fHx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7313,9 +7216,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "fHU" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/glitter/white{
@@ -7363,12 +7264,10 @@
 /area/shuttle/turbolift/tertiary)
 "fJe" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -7379,12 +7278,10 @@
 /area/medical/cryo)
 "fJn" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/grid/mono,
@@ -7397,6 +7294,11 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"fKw" = (
+/obj/structure/chair/stool,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/medical/medbay/lobby)
 "fKC" = (
 /obj/structure/table/wood/poker,
 /obj/item/skub,
@@ -7467,6 +7369,19 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/library)
+"fOA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/disposalpipe/sorting/wrap{
+	dir = 8
+	},
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "fPd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7502,9 +7417,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "fQz" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -7547,8 +7460,7 @@
 "fUQ" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -7562,9 +7474,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "fWN" = (
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
@@ -7593,8 +7503,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/structure/holosign/barrier/atmos,
@@ -7671,17 +7580,13 @@
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "gbo" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame3/central)
@@ -7738,8 +7643,7 @@
 "gdj" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -7751,8 +7655,7 @@
 /area/hallway/nsv/deck2/frame3/central)
 "gdr" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
@@ -7770,7 +7673,6 @@
 	req_one_access_txt = "46"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -7787,9 +7689,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "gdO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7803,15 +7703,13 @@
 /area/maintenance/nsv/deck2/starboard)
 "geL" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame3/central)
 "geP" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile,
@@ -7823,8 +7721,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7833,13 +7730,14 @@
 /area/nsv/crew_quarters/heads/maa)
 "gfj" = (
 /turf/open/floor/plasteel/grid/lino,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "ggL" = (
 /obj/machinery/atmospherics/pipe/simple/multiz,
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -7899,9 +7797,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "glj" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -7994,19 +7890,21 @@
 "gow" = (
 /obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "gpd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "gpI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -8026,8 +7924,7 @@
 /area/crew_quarters/kitchen)
 "gqi" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile,
@@ -8049,8 +7946,7 @@
 "grb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8077,9 +7973,7 @@
 	},
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "gsB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -8134,9 +8028,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "gwc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -8148,13 +8040,10 @@
 	pixel_y = 26
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "gwH" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8171,9 +8060,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "gxq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -8184,9 +8071,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "gxQ" = (
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
@@ -8203,7 +8088,6 @@
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "gyz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
@@ -8222,8 +8106,7 @@
 /area/quartermaster/storage)
 "gyK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/janitor)
@@ -8246,16 +8129,20 @@
 /area/nsv/weapons/fore)
 "gBj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/carpet/blue,
 /area/medical/storage)
+"gCb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/noslip/dark,
+/area/nsv/weapons/nuclear)
 "gCk" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/light{
@@ -8280,8 +8167,7 @@
 "gCW" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame3/central)
@@ -8324,6 +8210,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "gGD" = (
@@ -8348,9 +8235,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "gHb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -8362,12 +8247,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
@@ -8432,8 +8315,7 @@
 /area/quartermaster/storage)
 "gJr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/template_noop,
 /area/maintenance/nsv/deck2/starboard)
@@ -8482,9 +8364,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "gKV" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -8492,9 +8372,7 @@
 	},
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "gLk" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -8512,8 +8390,7 @@
 /obj/machinery/door/window/eastright{
 	base_state = "left";
 	icon_state = "left";
-	name = "Danger: Conveyor Access";
-	req_access_txt = "0"
+	name = "Danger: Conveyor Access"
 	},
 /obj/machinery/conveyor{
 	dir = 1;
@@ -8545,9 +8422,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "gMM" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay)
@@ -8572,8 +8447,7 @@
 "gNA" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8633,12 +8507,10 @@
 "gPK" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/medical/medbay)
@@ -8697,8 +8569,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/quartermaster/storage)
@@ -8722,9 +8593,7 @@
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "gTr" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -8754,9 +8623,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "gWR" = (
 /obj/structure/sign/directions/science{
 	dir = 1;
@@ -8839,16 +8706,15 @@
 /turf/open/floor/monotile,
 /area/quartermaster/office)
 "gZt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/monotile,
@@ -8874,8 +8740,7 @@
 "hco" = (
 /obj/effect/landmark/start/botanist,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hydroponics)
@@ -8906,8 +8771,7 @@
 "hes" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -8933,8 +8797,7 @@
 /area/quartermaster/office)
 "hfh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -8957,26 +8820,23 @@
 	dir = 6
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "hfE" = (
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "hgw" = (
 /obj/machinery/door/airlock/ship/medical,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -8985,12 +8845,10 @@
 /area/medical/medbay/lobby)
 "hgW" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9011,12 +8869,10 @@
 /area/medical/medbay)
 "hha" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -9046,6 +8902,13 @@
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
+/area/maintenance/nsv/deck2/starboard)
+"hhL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "hhO" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -9104,9 +8967,7 @@
 "hiS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "hjg" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -9156,8 +9017,7 @@
 /area/maintenance/nsv/deck2/port)
 "hlk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9185,8 +9045,7 @@
 "hlO" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9219,8 +9078,7 @@
 /area/maintenance/nsv/deck2/port)
 "hmK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -9248,8 +9106,7 @@
 "hnD" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9275,12 +9132,10 @@
 "hoT" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9355,9 +9210,7 @@
 "hqk" = (
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/grid/lino,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "hqp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -9376,9 +9229,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "hrH" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/rack,
@@ -9386,14 +9237,15 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck2/port)
+"hrO" = (
+/turf/closed/wall/steel,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "hrT" = (
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/airlock/ship/medical{
 	name = "Accident And Emergency"
@@ -9413,8 +9265,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9475,9 +9326,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "hun" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall/steel,
@@ -9498,8 +9347,7 @@
 "hwi" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/structure/closet/wardrobe/white,
 /obj/structure/cable{
@@ -9526,8 +9374,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
@@ -9553,8 +9400,7 @@
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
@@ -9569,9 +9415,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "hyJ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -9585,7 +9429,6 @@
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
 /obj/structure/curtain/obscuring/grey,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/library)
@@ -9670,9 +9513,6 @@
 /area/maintenance/nsv/deck2/starboard)
 "hAF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
 "hAO" = (
@@ -9760,9 +9600,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "hEt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9801,8 +9639,7 @@
 "hFz" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9889,12 +9726,10 @@
 "hLn" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grid/mono,
@@ -9903,9 +9738,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paicard,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "hNa" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9978,8 +9811,7 @@
 "hNX" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -9991,9 +9823,7 @@
 	dir = 6
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "hQI" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Library"
@@ -10008,8 +9838,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -10024,8 +9853,7 @@
 /area/crew_quarters/kitchen/coldroom)
 "hQQ" = (
 /obj/machinery/sleeper{
-	dir = 1;
-	icon_state = "sleeper"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/surgery)
@@ -10096,8 +9924,7 @@
 /area/crew_quarters/kitchen/coldroom)
 "hRZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
@@ -10110,8 +9937,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "hTw" = (
 /obj/structure/chair/pew/right{
-	dir = 8;
-	icon_state = "pewend_right"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -10190,6 +10016,21 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
 /area/nsv/weapons/fore)
+"hVI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
+/area/medical/medbay)
 "hVK" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -10205,9 +10046,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "hWv" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Chemistry Manufacturing";
@@ -10259,9 +10098,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/monotile,
 /area/quartermaster/storage)
 "hYl" = (
@@ -10293,17 +10129,20 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "hYS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "hZc" = (
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -10316,12 +10155,10 @@
 "hZt" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10338,9 +10175,7 @@
 "iaE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "iaH" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/apron/surgical,
@@ -10404,6 +10239,9 @@
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "icw" = (
@@ -10431,8 +10269,7 @@
 "icB" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
@@ -10472,9 +10309,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "idX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -10583,13 +10418,10 @@
 /area/medical/storage)
 "ikm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "ikT" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/monotile,
@@ -10641,13 +10473,10 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "inX" = (
 /obj/structure/fluff/paper{
 	dir = 5;
-	icon_state = "paper";
 	name = "undelivered letters"
 	},
 /obj/machinery/disposal/bin{
@@ -10672,9 +10501,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "ioK" = (
 /obj/machinery/light{
 	dir = 8
@@ -10688,9 +10515,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "ipR" = (
 /obj/structure/punching_bag,
 /obj/effect/turf_decal/tile/ship/full/blue,
@@ -10698,9 +10523,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "iqm" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10718,8 +10541,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -10734,9 +10556,7 @@
 	dir = 10
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "iqV" = (
 /obj/structure/sign/directions/command{
 	dir = 1
@@ -10799,14 +10619,11 @@
 /area/chapel/main)
 "ish" = (
 /obj/machinery/computer/ship/dradis/minor/console{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/grid/lino,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "isk" = (
 /obj/machinery/light_switch/north,
 /turf/open/floor/monotile,
@@ -10881,13 +10698,12 @@
 "ivv" = (
 /obj/structure/sign/ship/nosmoking,
 /turf/closed/wall/steel,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "iwh" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /obj/item/folder,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/purple,
 /area/library)
 "iwn" = (
@@ -10905,8 +10721,7 @@
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10941,14 +10756,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "iAh" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/monotile/dark,
-/area/quartermaster/storage)
+/obj/structure/closet/radiation,
+/turf/open/floor/monotile,
+/area/maintenance/nsv/deck2/port)
 "iAi" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -10981,8 +10791,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hydroponics)
@@ -11031,12 +10840,10 @@
 /area/nsv/weapons/fore)
 "iDu" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/grid/mono,
@@ -11052,8 +10859,7 @@
 "iEj" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -11177,9 +10983,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "iKv" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -11211,7 +11015,7 @@
 	name = "40mm torpedo construction manual"
 	},
 /obj/structure/table/wood,
-/turf/open/floor/monotile/dark/airless,
+/turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "iLR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -11223,8 +11027,7 @@
 /area/chapel/main)
 "iMw" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -11257,12 +11060,10 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/machinery/requests_console{
 	department = "Munitions";
@@ -11290,13 +11091,10 @@
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "iNI" = (
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -11359,18 +11157,14 @@
 /area/hallway/nsv/deck2/frame2/central)
 "iPT" = (
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "iPW" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11409,12 +11203,10 @@
 "iQJ" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11429,8 +11221,7 @@
 /area/maintenance/nsv/deck2/port)
 "iRg" = (
 /obj/machinery/camera/autoname{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/open/floor/carpet/blue,
 /area/lawoffice)
@@ -11479,9 +11270,7 @@
 	},
 /obj/effect/turf_decal/pool,
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "iUf" = (
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plasteel/grid/steel,
@@ -11508,12 +11297,10 @@
 "iXL" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame1/central)
@@ -11543,15 +11330,13 @@
 "iZK" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame1/central)
@@ -11563,9 +11348,7 @@
 	dir = 4
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "jac" = (
 /obj/machinery/light,
 /turf/open/floor/monotile,
@@ -11587,17 +11370,13 @@
 	name = "Crew Quarters"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "jbD" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
@@ -11606,9 +11385,20 @@
 /area/maintenance/nsv/deck2/starboard)
 "jbR" = (
 /turf/closed/wall/steel,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
+"jcj" = (
+/obj/structure/rack,
+/obj/item/radio/headset/munitions/munitions_tech{
+	icon_state = "mun_headset_alt"
+	},
+/obj/item/radio/headset/munitions/munitions_tech{
+	icon_state = "mun_headset_alt"
+	},
+/obj/item/radio/headset/munitions/munitions_tech{
+	icon_state = "mun_headset_alt"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "jcq" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
@@ -11633,9 +11423,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "jdt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 8
@@ -11784,12 +11572,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "jhG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -11816,9 +11602,7 @@
 	dir = 8
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "jiv" = (
 /obj/structure/cable{
 	icon_state = "5-8"
@@ -11833,8 +11617,7 @@
 /area/maintenance/nsv/deck2/port)
 "jiX" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame3/central)
@@ -11857,9 +11640,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "jku" = (
 /obj/machinery/bookbinder,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -11892,7 +11673,6 @@
 "jlS" = (
 /obj/structure/sign/ship/smoking{
 	dir = 4;
-	icon_state = "smoking";
 	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/glitter/white{
@@ -11911,9 +11691,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "jmV" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -11927,13 +11705,10 @@
 "jnD" = (
 /obj/effect/turf_decal/tile/ship/full/blue,
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_x = -26
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "jnI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -11967,9 +11742,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "jrS" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/item/radio/intercom/directional/north,
@@ -11977,19 +11750,16 @@
 /area/hydroponics)
 "jrT" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame1/central)
 "jsi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/medical/storage)
@@ -12012,8 +11782,7 @@
 /area/nsv/weapons/fore)
 "jtI" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12038,9 +11807,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "jtL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12122,8 +11889,10 @@
 /area/quartermaster/storage)
 "jwl" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/obscuring/grey,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "cmoshutter_pegasus"
+	},
 /turf/open/floor/plating,
 /area/medical/cryo)
 "jwt" = (
@@ -12220,8 +11989,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay/lobby)
@@ -12245,6 +12013,7 @@
 	c_tag = "Departure Lounge - Starboard Aft";
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "jyp" = (
@@ -12260,9 +12029,7 @@
 "jyJ" = (
 /obj/structure/closet/secure_closet/bar,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "jzB" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Radiation Bunker"
@@ -12296,9 +12063,7 @@
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "jAx" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -12380,12 +12145,10 @@
 /area/nsv/weapons/fore)
 "jDE" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12413,8 +12176,7 @@
 "jEt" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
@@ -12429,18 +12191,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "jFD" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -12480,6 +12241,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"jGl" = (
+/turf/open/floor/monotile,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "jGu" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Surgery";
@@ -12497,6 +12261,13 @@
 "jGT" = (
 /turf/closed/wall/steel,
 /area/medical/medbay/lobby)
+"jHm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "jHn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
@@ -12513,9 +12284,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "jJa" = (
 /obj/structure/cable{
 	icon_state = "6-8"
@@ -12565,8 +12334,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -12593,8 +12361,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "jMK" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -12646,8 +12413,7 @@
 "jOL" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -12728,8 +12494,7 @@
 	layer = 2.9
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 4;
-	icon_state = "pipe-t"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
@@ -12752,9 +12517,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "jRS" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/exit/departure_lounge)
@@ -12792,8 +12555,7 @@
 /area/crew_quarters/dorms)
 "jTm" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -12801,6 +12563,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame3/central)
 "jTM" = (
@@ -12835,9 +12598,7 @@
 	dir = 5
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "jUr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -12859,9 +12620,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "jUY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -12901,12 +12660,10 @@
 /area/maintenance/nsv/deck2/starboard)
 "jWS" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame1/central)
@@ -12949,8 +12706,7 @@
 /area/hallway/nsv/deck2/frame3/central)
 "jZz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/quartermaster/office)
@@ -12962,8 +12718,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13023,6 +12778,19 @@
 /obj/structure/munitions_trolley,
 /turf/open/floor/monotile,
 /area/quartermaster/office)
+"kdH" = (
+/obj/structure/table/reinforced,
+/obj/item/grenade/chem_grenade,
+/obj/item/book/manual/wiki/grenades,
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/medical/chemistry)
 "kfj" = (
 /obj/machinery/button/crematorium{
 	id = "crematoriumChapel";
@@ -13033,19 +12801,15 @@
 /area/chapel/office)
 "kfo" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay/lobby)
 "kfq" = (
-/obj/machinery/power/apc/auto_name/east{
-	pixel_x = 24
-	},
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
@@ -13056,7 +12820,6 @@
 "kgc" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = 26
 	},
 /obj/machinery/camera/autoname,
@@ -13144,9 +12907,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "kjb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13207,8 +12968,7 @@
 "klQ" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/landmark/zebra_interlock_point,
@@ -13224,6 +12984,14 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/monotile,
 /area/janitor)
+"kmQ" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/frame1/central)
 "kmW" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -13240,8 +13008,7 @@
 /area/crew_quarters/dorms)
 "knD" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -13258,9 +13025,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "knW" = (
 /obj/machinery/vending/medical,
 /obj/machinery/power/apc/auto_name/north{
@@ -13276,9 +13041,7 @@
 	name = "Adama's Finest Cigars"
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "kpf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13322,6 +13085,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
+"kqE" = (
+/obj/structure/chair/comfy/gauss/west,
+/turf/open/floor/monotile,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "kqL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/plasteel/freezer,
@@ -13332,8 +13099,7 @@
 "krY" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -13402,6 +13168,7 @@
 /obj/item/ammo_box/magazine/pdc/flak,
 /obj/item/ammo_box/magazine/pdc/flak,
 /obj/item/ammo_box/magazine/pdc/flak,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "kuK" = (
@@ -13422,7 +13189,6 @@
 "kwm" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = -26
 	},
 /turf/open/floor/monotile/dark,
@@ -13439,9 +13205,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "kwZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -13460,12 +13224,10 @@
 /area/maintenance/nsv/deck2/starboard)
 "kxv" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway Central";
@@ -13510,12 +13272,10 @@
 "kyK" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame2/central)
@@ -13552,9 +13312,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "kBs" = (
 /obj/effect/spawner/room/tenxfive,
 /turf/template_noop,
@@ -13568,21 +13326,17 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "kCQ" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "kCR" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -13596,12 +13350,10 @@
 /area/maintenance/nsv/deck2/starboard)
 "kDM" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/grid/mono,
@@ -13659,9 +13411,7 @@
 	name = "public gauss access shutters"
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "kFQ" = (
 /obj/structure/table/glass,
 /obj/item/toy/talking/AI,
@@ -13671,9 +13421,7 @@
 /obj/structure/table/reinforced,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "kGC" = (
 /obj/structure/cable{
 	icon_state = "4-9"
@@ -13733,9 +13481,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "kKm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13790,8 +13536,7 @@
 "kLg" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -13829,12 +13574,10 @@
 /area/maintenance/nsv/deck2/port)
 "kLY" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grid/mono,
@@ -13842,8 +13585,7 @@
 "kMl" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame2/central)
@@ -13923,12 +13665,10 @@
 /area/maintenance/nsv/deck2/starboard)
 "kPl" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13944,9 +13684,7 @@
 	},
 /obj/machinery/holopad,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "kQT" = (
 /obj/structure/bed,
 /obj/structure/bed{
@@ -14017,8 +13755,7 @@
 /area/quartermaster/storage)
 "kTv" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 1;
-	icon_state = "morgue1"
+	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/monotile,
@@ -14039,9 +13776,7 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "kVL" = (
-/obj/machinery/advanced_airlock_controller/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/advanced_airlock_controller/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "kWe" = (
@@ -14056,9 +13791,7 @@
 	icon_state = "mun_headset_alt"
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "kWm" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/box,
@@ -14102,14 +13835,11 @@
 /obj/item/ammo_box/magazine/pdc,
 /obj/item/ammo_box/magazine/pdc,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "kXH" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/grid/mono,
@@ -14142,9 +13872,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "kYw" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -14183,12 +13911,10 @@
 "kZv" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plasteel/grid/mono,
@@ -14201,12 +13927,10 @@
 /area/maintenance/nsv/deck2/port)
 "kZV" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/grid/mono,
@@ -14326,9 +14050,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "leH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14341,9 +14063,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "leW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14365,9 +14085,7 @@
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "lfx" = (
 /obj/item/reagent_containers/food/condiment/enzyme,
 /obj/item/reagent_containers/glass/beaker,
@@ -14422,10 +14140,11 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "lhd" = (
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/white,
@@ -14462,12 +14181,10 @@
 /area/janitor)
 "lkQ" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -14527,9 +14244,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "lmF" = (
 /obj/structure/bed/dogbed/runtime,
 /mob/living/simple_animal/pet/cat/Runtime,
@@ -14584,8 +14299,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
@@ -14593,8 +14307,7 @@
 /area/nsv/crew_quarters/heads/maa)
 "lnT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/medical)
@@ -14645,8 +14358,7 @@
 "lqc" = (
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/monotile,
@@ -14678,6 +14390,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "lqN" = (
@@ -14701,9 +14414,7 @@
 "lrv" = (
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "lrI" = (
 /obj/machinery/door/airlock/ship/public{
 	name = "Quiet Room"
@@ -14748,9 +14459,7 @@
 "lsZ" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "lto" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14825,26 +14534,12 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/chemistry)
-"lyy" = (
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1{
-	dir = 4
-	},
-/obj/machinery/advanced_airlock_controller/directional/north{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/open/floor/monotile/dark,
-/area/hallway/secondary/exit/departure_lounge)
 "lyz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14870,19 +14565,15 @@
 /area/maintenance/nsv/deck2/port)
 "lyU" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 1;
-	icon_state = "morgue1"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/medical/morgue)
 "lza" = (
-/obj/structure/closet/firecloset,
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame3/central)
 "lzf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
@@ -14898,8 +14589,7 @@
 /area/quartermaster/office)
 "lzx" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/camera/autoname{
@@ -14915,13 +14605,10 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "lzA" = (
 /obj/structure/chair/pew{
-	dir = 8;
-	icon_state = "pewmiddle"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -14965,6 +14652,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/quartermaster/sorting)
 "lAR" = (
@@ -14974,9 +14662,7 @@
 	},
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "lBm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14987,9 +14673,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "lBn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -15004,9 +14688,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "lBH" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/airalarm/kitchen_cold_room{
@@ -15042,8 +14724,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
@@ -15058,8 +14739,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "lCm" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/light{
@@ -15116,8 +14796,7 @@
 "lFs" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1;
-	icon_state = "warninglinecorner"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/medical/virology)
@@ -15138,16 +14817,13 @@
 /area/quartermaster/sorting)
 "lGO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "lHm" = (
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "lHn" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
@@ -15183,7 +14859,6 @@
 "lJM" = (
 /obj/structure/fluff/paper{
 	dir = 1;
-	icon_state = "paper";
 	name = "undelivered letters"
 	},
 /obj/structure/disposalpipe/junction/yjunction,
@@ -15215,11 +14890,13 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
@@ -15240,9 +14917,7 @@
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "lLl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -15283,9 +14958,22 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
+"lMH" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "gaussgang";
+	name = "public gauss access shutters"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/port)
 "lMN" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -15407,8 +15095,7 @@
 "lTM" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -15416,8 +15103,7 @@
 /area/hallway/nsv/deck2/frame3/central)
 "lTN" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/structure/closet/wardrobe/white,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -15432,13 +15118,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "lUo" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay/lobby)
@@ -15454,9 +15137,7 @@
 "lVK" = (
 /obj/structure/pool_ladder,
 /turf/open/indestructible/sound/pool/end,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "lVL" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/structure/bed/roller,
@@ -15529,8 +15210,7 @@
 /area/quartermaster/storage)
 "mah" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/tech/grid,
 /area/quartermaster/warehouse)
@@ -15545,8 +15225,7 @@
 /area/chapel/main)
 "mby" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -15568,6 +15247,9 @@
 /area/hallway/nsv/deck2/frame3/central)
 "mcX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "mdq" = (
@@ -15628,14 +15310,11 @@
 /area/hallway/nsv/deck2/frame1/central)
 "mhL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "mid" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/roller,
@@ -15659,12 +15338,10 @@
 /area/maintenance/nsv/deck2/starboard)
 "miL" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/light,
 /turf/open/floor/monotile,
@@ -15738,12 +15415,10 @@
 /area/chapel/main)
 "mkN" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/grid/mono,
@@ -15764,20 +15439,16 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "mlc" = (
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Public Radiation Bunker"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -15800,12 +15471,10 @@
 /area/lawoffice)
 "mmo" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -15821,9 +15490,7 @@
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "mna" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating{
@@ -15900,17 +15567,13 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "mrT" = (
 /obj/machinery/computer/cargo/request/console{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grid/lino,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "msa" = (
 /obj/item/twohanded/required/kirbyplants,
 /turf/open/floor/carpet,
@@ -15967,8 +15630,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
@@ -16023,10 +15685,8 @@
 	req_one_access_txt = "45"
 	},
 /obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
@@ -16037,9 +15697,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "mwV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -16062,9 +15720,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "myf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -16091,9 +15747,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "mzS" = (
 /obj/structure/sign/ship/nosmoking,
 /turf/closed/wall/steel,
@@ -16114,9 +15768,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/ship/full/red,
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "mAL" = (
 /obj/structure/cable{
 	icon_state = "1-10"
@@ -16154,9 +15806,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "mBc" = (
 /obj/structure/closet/cardboard,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -16231,6 +15881,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "mEU" = (
@@ -16245,9 +15897,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /obj/effect/turf_decal/tile/ship/full/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -16270,11 +15919,7 @@
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
 "mFX" = (
-/obj/structure/closet/crate,
-/obj/item/camera_film{
-	pixel_x = -3;
-	pixel_y = 5
-	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "mGI" = (
@@ -16305,6 +15950,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/monotile,
 /area/medical/chemistry)
 "mIS" = (
@@ -16325,8 +15971,7 @@
 /area/medical/genetics)
 "mJV" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16376,6 +16021,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
 "mLH" = (
@@ -16417,8 +16065,7 @@
 /area/nsv/weapons/fore)
 "mML" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -16445,12 +16092,10 @@
 /area/hydroponics)
 "mOE" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame2/central)
@@ -16509,9 +16154,7 @@
 	icon_state = "nanotrasen_sign5"
 	},
 /turf/closed/wall/steel,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "mQm" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -16535,12 +16178,10 @@
 /area/quartermaster/storage)
 "mQC" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/status_display/ai/north,
 /turf/open/floor/plasteel/grid/mono,
@@ -16566,9 +16207,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "mRr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -16615,13 +16254,10 @@
 /area/hallway/nsv/deck2/frame2/central)
 "mTb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "mTs" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -16631,9 +16267,7 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "mUn" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/grid/steel,
@@ -16669,8 +16303,7 @@
 /area/medical/genetics)
 "mWa" = (
 /obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "cryopod-open"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Cryogenics Lounge";
@@ -16681,8 +16314,7 @@
 /area/crew_quarters/cryopods)
 "mXc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
@@ -16710,12 +16342,10 @@
 /area/lawoffice)
 "mXv" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16725,8 +16355,7 @@
 "mYz" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/medical/cryo)
@@ -16748,9 +16377,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "mZn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -16803,8 +16430,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/quartermaster/office)
@@ -16816,8 +16442,7 @@
 "nbg" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/grid/mono,
@@ -16828,9 +16453,7 @@
 	dir = 9
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "nbq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16860,9 +16483,7 @@
 	name = "40 mm flak rounds"
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "nbH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -16877,17 +16498,18 @@
 /area/hydroponics)
 "ncB" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/obscuring/grey,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	dir = 4;
+	id = "cmoshutter_pegasus"
+	},
 /turf/open/floor/plating,
 /area/medical/genetics)
 "ncJ" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -16917,10 +16539,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "ndv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -16942,8 +16565,7 @@
 /area/medical/virology)
 "nek" = (
 /obj/structure/chair/pew{
-	dir = 8;
-	icon_state = "pewmiddle"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -16983,8 +16605,10 @@
 /obj/structure/chair/office/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
@@ -17024,8 +16648,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -17097,6 +16720,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
+"njZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "nkg" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/structure/cable{
@@ -17146,12 +16779,26 @@
 /area/maintenance/nsv/deck2/port)
 "nml" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
 /area/medical/cryo)
+"nmx" = (
+/obj/machinery/door/airlock/highsecurity/ship{
+	name = "Weapons Bay";
+	req_one_access_txt = "69"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile,
+/area/nsv/weapons/nuclear)
 "nmO" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -17169,8 +16816,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "nnJ" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile,
@@ -17199,9 +16845,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "npO" = (
 /obj/machinery/light_switch/north,
 /turf/open/floor/monotile/light,
@@ -17288,18 +16932,14 @@
 	pixel_y = 23
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "ntW" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17332,9 +16972,7 @@
 	name = "WARNING: WEAR HEARING PROTECTION"
 	},
 /turf/closed/wall/steel,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "nuK" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -17366,12 +17004,12 @@
 	},
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "nvG" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/obscuring/grey,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "cmoshutter_pegasus"
+	},
 /turf/open/floor/plating,
 /area/medical/cryo)
 "nwD" = (
@@ -17388,6 +17026,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
+"nyt" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/nsv/deck2/starboard)
 "nzx" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating{
@@ -17440,9 +17084,7 @@
 	receive_ore_updates = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "nDh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -17456,8 +17098,7 @@
 "nDp" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/door/airlock/ship/public/glass,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -17473,10 +17114,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "nDY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -17528,9 +17168,7 @@
 	},
 /obj/effect/turf_decal/pool,
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "nEP" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -17601,6 +17239,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel/freezer,
 /area/medical/virology)
+"nGv" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "nGG" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -17615,16 +17257,12 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "nGN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plating,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "nHO" = (
 /obj/structure/closet,
 /obj/item/storage/box/lights/mixed,
@@ -17664,8 +17302,7 @@
 /area/maintenance/nsv/deck2/port)
 "nHW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
@@ -17686,12 +17323,10 @@
 /area/medical/cryo)
 "nII" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -17770,9 +17405,7 @@
 	name = "railgun projectile crate"
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "nKm" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/r_wall,
@@ -17780,12 +17413,10 @@
 "nKZ" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame1/central)
@@ -17810,6 +17441,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
 /area/medical/virology)
+"nMS" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/grid/mono,
+/area/hallway/nsv/deck2/frame3/central)
 "nNh" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -17850,9 +17491,7 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "nQw" = (
 /turf/template_noop,
 /area/maintenance/nsv/deck2/port)
@@ -17921,7 +17560,6 @@
 	},
 /area/maintenance/nsv/deck2/starboard)
 "nSO" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -17934,16 +17572,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
 	},
+/obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "nSP" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "nSR" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -17952,9 +17587,7 @@
 	dir = 5
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "nTl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -17969,13 +17602,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "nTm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
@@ -17984,8 +17614,7 @@
 /area/medical/virology)
 "nUa" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -18016,15 +17645,8 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
 /area/maintenance/nsv/deck2/port)
 "nVw" = (
@@ -18075,8 +17697,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1;
-	icon_state = "warninglinecorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/full/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -18147,9 +17768,7 @@
 	dir = 4
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "nYj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -18193,8 +17812,7 @@
 /area/medical/medbay)
 "nZe" = (
 /obj/structure/chair/sofa/corner{
-	dir = 8;
-	icon_state = "sofacorner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -18232,9 +17850,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "oaO" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -18272,8 +17888,7 @@
 "obD" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -18316,9 +17931,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "ocr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -18332,11 +17945,13 @@
 "ocF" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/airalarm{
+	pixel_y = 23
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay/lobby)
@@ -18360,8 +17975,7 @@
 /area/maintenance/nsv/deck2/port)
 "odZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/structure/chair/wood/normal{
 	dir = 4
@@ -18421,9 +18035,7 @@
 "ohE" = (
 /obj/effect/turf_decal/tile/ship/full/blue,
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "ohF" = (
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Weapons Bay";
@@ -18438,9 +18050,7 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "ohR" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/door/airlock/ship/external/glass{
@@ -18519,6 +18129,9 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
 "ojL" = (
@@ -18547,9 +18160,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "oke" = (
 /turf/closed/wall/steel,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "okA" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -18562,6 +18173,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"ola" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 4
+	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "olf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -18571,9 +18189,11 @@
 /turf/open/floor/monotile/light,
 /area/crew_quarters/heads/cmo)
 "olk" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile/ship,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "olJ" = (
@@ -18613,8 +18233,7 @@
 "onb" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -18624,6 +18243,13 @@
 	},
 /turf/open/floor/engine,
 /area/medical/cryo)
+"onH" = (
+/obj/structure/sign/ship/securearea{
+	dir = 8;
+	name = "WARNING: WEAR HEARING PROTECTION"
+	},
+/turf/closed/wall/steel,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "onV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -18633,9 +18259,7 @@
 	pixel_x = -22
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "ooc" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -18669,12 +18293,10 @@
 /area/medical/virology)
 "oqn" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/structure/disposalpipe/segment,
@@ -18686,9 +18308,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "oqI" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/monotile,
@@ -18705,6 +18325,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/monotile,
 /area/medical/medbay)
 "orP" = (
@@ -18746,8 +18367,7 @@
 /area/medical/storage)
 "orX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/carpet/ship/blue,
 /area/hallway/nsv/deck2/frame3/central)
@@ -18769,13 +18389,10 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "osQ" = (
 /obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "cryopod-open"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -18796,8 +18413,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/maintenance/port{
@@ -18843,9 +18459,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/grid/lino,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "ovd" = (
 /obj/structure/sign/ship/radiation{
 	name = "Radiation Shelter"
@@ -18871,18 +18485,16 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "ovl" = (
 /obj/structure/extinguisher_cabinet/east,
-/obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/monotile,
 /area/quartermaster/office)
 "ovG" = (
@@ -18917,9 +18529,7 @@
 /area/chapel/main)
 "owb" = (
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "owA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -18954,8 +18564,7 @@
 "oxL" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -19005,11 +18614,15 @@
 /turf/open/floor/monotile,
 /area/hydroponics)
 "oyX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/atmospherics_engine)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "oyY" = (
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/plating{
@@ -19028,8 +18641,7 @@
 /area/maintenance/department/medical)
 "ozh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/template_noop,
 /area/maintenance/nsv/deck2/starboard)
@@ -19184,9 +18796,7 @@
 /obj/effect/turf_decal/pool/corner,
 /obj/machinery/light_switch/west,
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "oEl" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/machinery/computer/ship/viewscreen,
@@ -19212,14 +18822,12 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/medical/genetics)
 "oET" = (
 /obj/machinery/door/airlock/ship/medical{
-	dir = 2;
 	name = "Medical Evacuation";
 	req_one_access_txt = "5"
 	},
@@ -19264,12 +18872,10 @@
 /area/maintenance/nsv/deck2/starboard)
 "oGS" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plasteel/grid/mono,
@@ -19307,8 +18913,7 @@
 /area/maintenance/nsv/deck2/port)
 "oIX" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19349,8 +18954,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Virology - Airlock";
@@ -19406,13 +19010,13 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "oKK" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/obscuring/grey,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "cmoshutter_pegasus"
+	},
 /turf/open/floor/plating,
 /area/medical/cryo)
 "oLm" = (
@@ -19447,8 +19051,7 @@
 "oMB" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
@@ -19488,9 +19091,7 @@
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "oRj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -19502,8 +19103,7 @@
 "oRG" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/structure/chair/office{
 	dir = 8
@@ -19527,26 +19127,22 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "oTd" = (
-/obj/machinery/computer/cloning{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
+/obj/machinery/dna_scannernew,
 /turf/open/floor/engine,
 /area/medical/genetics)
 "oTe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/template_noop,
 /area/maintenance/nsv/deck2/port)
 "oTg" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/door/airlock/ship/external/glass{
@@ -19559,12 +19155,10 @@
 "oTi" = (
 /obj/structure/sign/ship/nosmoking{
 	dir = 8;
-	icon_state = "nosmoking";
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame2/central)
@@ -19629,8 +19223,7 @@
 /area/maintenance/nsv/deck2/port)
 "oVo" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/regular,
@@ -19697,15 +19290,6 @@
 /area/crew_quarters/theatre)
 "oWS" = (
 /obj/structure/closet/lasertag/red,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/maintenance/nsv/deck2/port)
 "oWY" = (
@@ -19714,9 +19298,7 @@
 	dir = 10
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "oXj" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/stripes/line,
@@ -19731,9 +19313,7 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plating,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "oXG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19752,10 +19332,8 @@
 	req_one_access_txt = "45"
 	},
 /obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
@@ -19904,8 +19482,7 @@
 /area/chapel/office)
 "pdM" = (
 /obj/structure/chair/pew{
-	dir = 8;
-	icon_state = "pewmiddle"
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -19915,13 +19492,10 @@
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/camera/autoname{
-	dir = 9;
-	icon_state = "camera"
+	dir = 9
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "pdV" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -19953,11 +19527,19 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/nsv/deck2/starboard)
+"pik" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/pool{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/monotile/light,
+/area/crew_quarters/fitness/pool_area)
 "piK" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/landmark/zebra_interlock_point,
@@ -20054,12 +19636,10 @@
 "pkb" = (
 /obj/machinery/door/airlock/ship/public/glass,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -20133,12 +19713,10 @@
 /area/hallway/nsv/deck2/frame3/central)
 "pny" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -20251,10 +19829,11 @@
 	},
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "pqP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -20289,12 +19868,10 @@
 "prK" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20320,9 +19897,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "psL" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -20349,19 +19924,16 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hydroponics)
 "pud" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -20370,8 +19942,7 @@
 /area/hallway/nsv/deck2/frame1/central)
 "puh" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20404,12 +19975,10 @@
 /area/quartermaster/office)
 "pvB" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/doorButtons/access_button{
 	idDoor = "virology_airlock_interior";
@@ -20474,12 +20043,10 @@
 "pwT" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/camera/autoname{
@@ -20520,9 +20087,7 @@
 	})
 "pxM" = (
 /turf/open/indestructible/sound/pool/end,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "pxQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -20532,9 +20097,7 @@
 "pze" = (
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "pzp" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -20547,8 +20110,7 @@
 "pzB" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/medical/cryo)
@@ -20571,8 +20133,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "pAE" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame2/central)
@@ -20582,9 +20143,7 @@
 	},
 /obj/effect/landmark/start/munitions_tech,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "pCm" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -20650,9 +20209,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/grid/lino,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "pEC" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin/construction,
@@ -20677,8 +20234,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "pFw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20699,12 +20255,10 @@
 /area/medical/medbay/lobby)
 "pFP" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/west{
 	pixel_x = -24
@@ -20715,7 +20269,6 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame2/central)
 "pFY" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -20768,9 +20321,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "pJf" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -20779,8 +20330,7 @@
 /area/chapel/main)
 "pJA" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/structure/closet/wardrobe/white,
@@ -20791,8 +20341,7 @@
 /area/medical/medbay/lobby)
 "pJN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
@@ -20811,8 +20360,7 @@
 /area/medical/storage)
 "pKC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/maintenance/port{
@@ -20843,9 +20391,7 @@
 "pMO" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "pMY" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -20858,11 +20404,14 @@
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/light,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "pOb" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/maintenance/nsv/deck2/port)
 "pOk" = (
@@ -20926,6 +20475,31 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/dorms)
+"pRo" = (
+/obj/structure/rack,
+/obj/item/radio/headset/munitions/munitions_tech{
+	icon_state = "mun_headset_alt"
+	},
+/obj/item/radio/headset/munitions/munitions_tech{
+	icon_state = "mun_headset_alt"
+	},
+/obj/item/radio/headset/munitions/munitions_tech{
+	icon_state = "mun_headset_alt"
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
+"pRE" = (
+/obj/effect/decal/cleanable/glitter/white{
+	layer = 4.1;
+	name = "smoke"
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/hallway/nsv/deck2/frame3/central)
 "pRM" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20934,6 +20508,9 @@
 /obj/machinery/airlock_sensor/incinerator_atmos{
 	pixel_x = -8;
 	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/atmospherics_engine)
@@ -21039,9 +20616,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "pVh" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating{
@@ -21069,6 +20644,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck2/port)
+"pXX" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/nsv/deck2/starboard)
 "pYm" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/space/basic,
@@ -21113,9 +20694,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "pZL" = (
 /obj/structure/cable{
 	icon_state = "4-9"
@@ -21142,9 +20721,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "qac" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -21335,8 +20912,7 @@
 "qiY" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -21427,9 +21003,7 @@
 "qod" = (
 /obj/machinery/camera/autoname,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "qoy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21477,8 +21051,7 @@
 "qpn" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -21512,21 +21085,16 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "qrr" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
@@ -21545,9 +21113,7 @@
 "qsD" = (
 /obj/effect/turf_decal/tile/ship/full/blue,
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "qsP" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Genetics Lab";
@@ -21558,8 +21124,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/medical/genetics)
@@ -21575,9 +21140,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "qtg" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/structure/cable{
@@ -21589,8 +21152,7 @@
 /area/maintenance/nsv/deck2/port)
 "qtM" = (
 /obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	icon_state = "blood1"
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -21611,8 +21173,7 @@
 /area/medical/genetics)
 "quy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -21663,12 +21224,10 @@
 /area/medical/medbay/lobby)
 "qwz" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/grid/mono,
@@ -21698,9 +21257,7 @@
 "qxd" = (
 /obj/structure/chair/stool,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "qxu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -21717,9 +21274,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "qxL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -21728,8 +21283,7 @@
 /area/maintenance/nsv/deck2/port)
 "qyc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
@@ -21740,22 +21294,19 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame3/central)
 "qyt" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Weapons Bay";
 	req_one_access_txt = "69"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
 "qyx" = (
@@ -21834,9 +21385,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "qAr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -21879,8 +21428,7 @@
 	})
 "qCV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -21902,9 +21450,7 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "qDz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -21934,9 +21480,7 @@
 /obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "qEE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21968,9 +21512,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "qGL" = (
 /obj/structure/chair/comfy/black{
 	dir = 4;
@@ -21980,16 +21522,13 @@
 /area/hallway/secondary/exit/departure_lounge)
 "qGU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "qHa" = (
 /obj/structure/chair,
 /obj/machinery/light_switch/north,
@@ -22011,9 +21550,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "qHQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -22078,9 +21615,7 @@
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "qLJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -22117,8 +21652,7 @@
 "qNW" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
@@ -22143,9 +21677,7 @@
 	name = "Drunken Sailor"
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "qOG" = (
 /obj/machinery/door/poddoor/ship{
 	id = "janigarage"
@@ -22211,9 +21743,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "qRN" = (
 /obj/structure/table/reinforced,
 /obj/item/stamp/denied{
@@ -22246,12 +21776,10 @@
 /area/maintenance/nsv/deck2/starboard)
 "qTx" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Cryo";
@@ -22272,12 +21800,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -22299,8 +21826,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
@@ -22338,9 +21864,7 @@
 /obj/item/clothing/head/ushanka,
 /obj/item/clothing/under/costume/soviet,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "qWz" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22382,17 +21906,13 @@
 /obj/item/clothing/under/costume/soviet,
 /obj/machinery/light,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "qZd" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22409,12 +21929,10 @@
 /area/medical/genetics)
 "qZp" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay)
@@ -22422,18 +21940,10 @@
 /obj/structure/chair/comfy/gauss/east,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "raj" = (
 /obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 4
+	icon_state = "1-10"
 	},
 /turf/open/floor/wood,
 /area/maintenance/nsv/deck2/port)
@@ -22479,12 +21989,10 @@
 /area/maintenance/nsv/deck2/port)
 "rdB" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/status_display/ai/north,
 /turf/open/floor/plasteel/grid/mono,
@@ -22540,12 +22048,10 @@
 "rgC" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame3/central)
@@ -22591,18 +22097,17 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8;
-	icon_state = "warningline"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -22620,8 +22125,7 @@
 "rjA" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22640,8 +22144,7 @@
 /area/lawoffice)
 "rjS" = (
 /obj/machinery/cryopod{
-	dir = 4;
-	icon_state = "cryopod-open"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -22657,13 +22160,10 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "rkv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
@@ -22687,8 +22187,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile,
@@ -22717,12 +22216,10 @@
 /area/maintenance/nsv/deck2/starboard)
 "rnh" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -22733,12 +22230,10 @@
 /area/medical/medbay)
 "rni" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -22757,9 +22252,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "rnP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
@@ -22796,8 +22289,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay)
@@ -22864,8 +22356,7 @@
 "rtd" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22875,12 +22366,10 @@
 /area/medical/cryo)
 "rtl" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -22900,9 +22389,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "rtZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -22912,7 +22399,6 @@
 "rua" = (
 /obj/structure/fluff/paper{
 	dir = 4;
-	icon_state = "paper";
 	name = "undelivered letters"
 	},
 /obj/structure/table,
@@ -22947,8 +22433,7 @@
 "ruW" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22964,10 +22449,8 @@
 	name = "Chief Medical Officer";
 	req_one_access_txt = "40"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "rwq" = (
@@ -22978,9 +22461,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "rwv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -22992,9 +22473,7 @@
 /area/maintenance/nsv/deck2/port)
 "rxe" = (
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "rxB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23003,8 +22482,7 @@
 /area/crew_quarters/theatre)
 "rxW" = (
 /obj/machinery/computer/shuttle/mining{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -23025,9 +22503,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "rzn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -23073,8 +22549,7 @@
 	})
 "rBk" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -23094,9 +22569,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "rBB" = (
 /turf/open/floor/carpet/blue,
 /area/lawoffice)
@@ -23129,9 +22602,7 @@
 	dir = 10
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "rDy" = (
 /obj/structure/sink{
 	dir = 4;
@@ -23151,10 +22622,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "rDO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23245,13 +22717,10 @@
 	dir = 10
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "rFF" = (
 /obj/structure/chair/sofa{
-	dir = 1;
-	icon_state = "sofamiddle"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -23287,8 +22756,7 @@
 "rJv" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
-	dir = 8;
-	icon_state = "warningline"
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
@@ -23307,9 +22775,7 @@
 	},
 /obj/effect/turf_decal/pool,
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "rJL" = (
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -23424,9 +22890,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "rOR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23464,9 +22928,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "rQG" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -23514,8 +22976,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/hydroponics)
@@ -23536,16 +22997,14 @@
 "rSR" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame1/central)
 "rUt" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23575,6 +23034,12 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/monotile,
 /area/medical/chemistry)
+"rVB" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/nsv/deck2/starboard)
 "rVN" = (
 /obj/structure/fluff/support_beam,
 /obj/structure/cable{
@@ -23653,9 +23118,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "rZN" = (
 /obj/machinery/door/airlock/ship/medical{
 	name = "Morgue";
@@ -23676,16 +23139,12 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "sau" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/obscuring/grey,
 /turf/open/floor/plating,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "sbY" = (
 /turf/open/floor/engine/airless,
 /area/space)
@@ -23733,17 +23192,13 @@
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/light_switch/west,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "sdm" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame3/central)
@@ -23883,14 +23338,11 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "siS" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/janitor)
@@ -23933,21 +23385,26 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck2/starboard)
+"slc" = (
+/obj/item/paper/guides/conveyor,
+/obj/machinery/computer/ship/viewscreen,
+/obj/structure/ladder,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "sld" = (
 /obj/machinery/libraryscanner,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet/purple,
 /area/library)
 "slk" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -23987,7 +23444,6 @@
 /area/maintenance/nsv/deck2/starboard)
 "smG" = (
 /obj/machinery/door/airlock/ship/medical{
-	dir = 2;
 	name = "Medical Evacuation";
 	req_one_access_txt = "5"
 	},
@@ -24050,9 +23506,7 @@
 	dir = 1
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "snV" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -24091,10 +23545,22 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"sqh" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "gaussgang";
+	name = "public gauss access shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "squ" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
@@ -24121,9 +23587,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "srV" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/steel,
@@ -24160,23 +23624,19 @@
 "stP" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/maintenance/nsv/deck2/port)
 "sul" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft Arm - Far"
@@ -24199,8 +23659,7 @@
 "svr" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/monotile,
@@ -24233,18 +23692,14 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "sxY" = (
 /obj/structure/sign/ship/securearea{
 	dir = 4;
 	name = "WARNING: WEAR HEARING PROTECTION"
 	},
 /turf/closed/wall/steel,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "syt" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -24293,12 +23748,10 @@
 /area/hydroponics)
 "sAN" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/camera{
@@ -24322,13 +23775,8 @@
 	dir = 4
 	},
 /turf/closed/wall/steel,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "sCQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -24337,6 +23785,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
@@ -24361,8 +23812,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "sDJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24487,8 +23937,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "sNe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -24496,8 +23945,7 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /obj/machinery/camera/autoname{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/security/checkpoint/supply)
@@ -24516,6 +23964,7 @@
 "sOp" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/purple,
 /area/library)
 "sOs" = (
@@ -24531,9 +23980,7 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "sOK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24561,14 +24008,11 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "sPj" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -24623,9 +24067,7 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/effect/turf_decal/tile/ship/full/red,
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "sRj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24640,9 +24082,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "sRn" = (
 /obj/machinery/conveyor{
 	dir = 5;
@@ -24666,8 +24106,7 @@
 /area/library)
 "sSl" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
@@ -24680,8 +24119,7 @@
 "sTc" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -24695,8 +24133,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -24713,18 +24150,14 @@
 /area/library)
 "sVT" = (
 /turf/closed/wall/steel,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "sVW" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "sWk" = (
 /obj/machinery/iv_drip,
 /obj/structure/cable{
@@ -24736,6 +24169,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/steel,
 /area/quartermaster/office)
+"sWN" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/nsv/deck2/starboard)
 "sWV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -24752,9 +24191,7 @@
 /obj/item/twohanded/required/pool/pool_noodle,
 /obj/item/twohanded/required/pool/rubber_ring,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "sXv" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -24784,15 +24221,7 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "sYA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/monotile,
 /area/maintenance/nsv/deck2/port)
 "sZx" = (
@@ -24833,9 +24262,7 @@
 /obj/machinery/food_cart,
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "taP" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/soft/orange,
@@ -24857,9 +24284,7 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "tbV" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -24882,14 +24307,11 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "tcH" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -24913,6 +24335,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
+/area/medical/chemistry)
+"tdI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "chem_privacy";
+	name = "privacy shutters"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/medical/chemistry)
 "tdJ" = (
 /obj/item/radio/intercom/directional/west,
@@ -24951,9 +24382,7 @@
 	icon_state = "nanotrasen_sign3"
 	},
 /turf/closed/wall/steel,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "tgt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -24966,13 +24395,10 @@
 /obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "thc" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/camera/autoname{
@@ -25017,9 +24443,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "tit" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/monotile,
@@ -25034,12 +24458,17 @@
 	layer = 2.9
 	},
 /obj/machinery/door/window/eastright{
-	dir = 4;
 	name = "Hydroponics Delivery";
 	req_access_txt = "35"
 	},
 /turf/open/floor/monotile,
 /area/hydroponics)
+"tju" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "tjw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -25049,14 +24478,12 @@
 	},
 /area/maintenance/nsv/deck2/starboard)
 "tjG" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "tkF" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -25074,9 +24501,7 @@
 "tkH" = (
 /obj/structure/chair/comfy/gauss/west,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "tlB" = (
 /obj/structure/cable{
 	icon_state = "4-10"
@@ -25113,14 +24538,11 @@
 	},
 /obj/machinery/light,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "tme" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
@@ -25156,10 +24578,11 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "tof" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -25171,8 +24594,7 @@
 	icon_state = "2-9"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -25193,8 +24615,7 @@
 "tpO" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25229,12 +24650,10 @@
 /area/medical/storage)
 "tqv" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/plasteel/grid/mono,
@@ -25245,12 +24664,10 @@
 /area/quartermaster/storage)
 "tqK" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -25291,9 +24708,7 @@
 	pixel_y = 23
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "trT" = (
 /obj/machinery/computer/security{
 	dir = 4
@@ -25311,8 +24726,7 @@
 /area/crew_quarters/heads/cmo)
 "tsa" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25327,12 +24741,10 @@
 /area/hallway/nsv/deck2/frame2/central)
 "tsn" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/door/airlock/ship/public/glass,
 /obj/machinery/door/firedoor/border_only/directional/east,
@@ -25382,8 +24794,7 @@
 /area/hydroponics)
 "tun" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -25429,9 +24840,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "twx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -25450,17 +24859,13 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "twy" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 8
@@ -25491,19 +24896,16 @@
 	name = "Crew Quarters"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/dorms)
 "tym" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8;
-	icon_state = "warningline"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -25618,8 +25020,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/medical/virology)
@@ -25700,9 +25101,7 @@
 /obj/item/kitchen/fork,
 /obj/structure/table,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "tHB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -25746,13 +25145,10 @@
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "tJb" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -25792,12 +25188,10 @@
 /area/engine/atmospherics_engine)
 "tKf" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay/lobby)
@@ -25837,8 +25231,7 @@
 /area/library)
 "tLg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
@@ -25858,8 +25251,7 @@
 /area/library)
 "tLx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -25867,9 +25259,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "tLB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -25893,6 +25283,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/monotile,
 /area/quartermaster/sorting)
 "tLJ" = (
@@ -25910,8 +25303,7 @@
 /area/quartermaster/storage)
 "tMf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
@@ -25958,6 +25350,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
+"tOv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/medical/medbay/lobby)
 "tOS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -25967,8 +25366,7 @@
 "tOW" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/landmark/zebra_interlock_point,
@@ -25986,9 +25384,7 @@
 /area/quartermaster/storage)
 "tPs" = (
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "tQb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -26020,6 +25416,13 @@
 /obj/machinery/light_switch/north,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
+"tRs" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "tRz" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/stripes/white/line{
@@ -26066,9 +25469,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "tTn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26095,6 +25496,12 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/virology)
+"tUX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/heads/cmo)
 "tVC" = (
 /obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -26102,13 +25509,11 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "tVL" = (
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/wood,
-/area/library)
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/plasteel/grid/steel,
+/area/quartermaster/storage)
 "tVX" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -26153,15 +25558,10 @@
 /area/maintenance/nsv/deck2/port)
 "tYf" = (
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "tZJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/open/floor/plating{
@@ -26227,16 +25627,13 @@
 /area/crew_quarters/kitchen)
 "ucu" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame3/central)
@@ -26246,6 +25643,17 @@
 /obj/item/clothing/head/kitty,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"ucG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/noslip/dark,
+/area/nsv/weapons/nuclear)
 "udp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26260,17 +25668,13 @@
 	pixel_x = -22
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "udN" = (
 /obj/effect/turf_decal/tile/ship/half/red{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/nsv/weapons/fore)
@@ -26281,8 +25685,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26301,6 +25704,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/maintenance/department/medical)
+"ueD" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck2/starboard)
 "ueZ" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess{
 	name = "Weapons Bay";
@@ -26318,25 +25727,20 @@
 /area/nsv/weapons/fore)
 "ufw" = (
 /obj/machinery/camera/autoname{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
 	},
 /turf/open/floor/plasteel/grid/lino,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "ugx" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26379,11 +25783,9 @@
 /turf/open/floor/wood,
 /area/maintenance/nsv/deck2/port)
 "ujC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmospherics_engine)
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "ukd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -26401,8 +25803,7 @@
 	req_one_access_txt = "69"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -26441,24 +25842,20 @@
 /area/engine/atmospherics_engine)
 "umw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "umE" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "umJ" = (
 /obj/structure/chair/sofa/right{
-	dir = 1;
-	icon_state = "sofaend_right"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -26491,9 +25888,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "uoQ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/mint,
@@ -26524,7 +25919,7 @@
 /turf/open/floor/monotile/dark,
 /area/quartermaster/sorting)
 "ura" = (
-/obj/structure/closet/firecloset,
+/obj/structure/closet/firecloset/full,
 /turf/open/floor/monotile,
 /area/quartermaster/sorting)
 "urc" = (
@@ -26564,9 +25959,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "usJ" = (
 /obj/structure/sign/ship/deck/two,
 /turf/closed/wall/steel,
@@ -26642,8 +26035,7 @@
 "uuB" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -26666,9 +26058,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
 "uvl" = (
@@ -26676,12 +26066,10 @@
 	name = "Public Radiation Bunker"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26762,8 +26150,7 @@
 /area/crew_quarters/theatre)
 "uyc" = (
 /obj/machinery/light/small/built{
-	dir = 1;
-	icon_state = "bulb-empty"
+	dir = 1
 	},
 /obj/structure/closet/crate,
 /obj/item/light/bulb,
@@ -26774,9 +26161,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "uyp" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_y = -6
@@ -26833,9 +26218,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "uAY" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -26935,9 +26318,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "uEf" = (
 /turf/open/floor/monotile,
 /area/crew_quarters/cryopods)
@@ -26981,12 +26362,10 @@
 /area/hydroponics)
 "uGV" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -27052,9 +26431,7 @@
 /area/maintenance/nsv/deck2/port)
 "uKb" = (
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "uKn" = (
 /obj/machinery/button/door{
 	id = "qm_warehouse";
@@ -27069,8 +26446,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -27111,14 +26487,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "uMi" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -27148,8 +26521,7 @@
 /area/quartermaster/office)
 "uOj" = (
 /obj/item/chair/wood{
-	dir = 1;
-	icon_state = "wooden_chair_toppled"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
@@ -27231,8 +26603,7 @@
 /area/nsv/weapons/fore)
 "uSD" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
 /obj/machinery/light{
@@ -27246,12 +26617,10 @@
 /area/medical/medbay)
 "uSO" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -27271,9 +26640,7 @@
 	icon_state = "boozeomat"
 	},
 /turf/closed/wall/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "uUP" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 9
@@ -27283,9 +26650,7 @@
 "uVA" = (
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "uVL" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -27335,12 +26700,10 @@
 /area/hallway/nsv/deck2/frame1/central)
 "uYF" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -27407,15 +26770,13 @@
 /area/nsv/weapons/fore)
 "vbS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "vcE" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
@@ -27477,7 +26838,6 @@
 	},
 /obj/structure/fluff/paper{
 	dir = 6;
-	icon_state = "paper";
 	name = "undelivered letters"
 	},
 /turf/open/floor/plating,
@@ -27487,7 +26847,6 @@
 /turf/open/floor/wood,
 /area/library)
 "vgv" = (
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
@@ -27496,6 +26855,9 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
+/obj/machinery/computer/cloning{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/medical/genetics)
 "vgF" = (
@@ -27503,8 +26865,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27557,9 +26918,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "viF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -27621,17 +26980,18 @@
 	dir = 4
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
+"vkU" = (
+/obj/effect/landmark/start/munitions_tech,
+/turf/open/floor/monotile,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "vlF" = (
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -27653,17 +27013,13 @@
 /obj/item/reagent_containers/food/snacks/rationpack,
 /obj/structure/table,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "vmm" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
@@ -27687,11 +27043,11 @@
 /turf/open/floor/monotile,
 /area/crew_quarters/kitchen)
 "vnx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -27699,12 +27055,10 @@
 "vop" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27720,8 +27074,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/medical/virology)
@@ -27768,6 +27121,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/tech/grid,
 /area/quartermaster/warehouse)
 "vqH" = (
@@ -27830,12 +27184,10 @@
 	name = "Crew Quarters"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 8;
-	icon_state = "door_open"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27844,9 +27196,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "vsP" = (
 /obj/structure/cable{
 	icon_state = "5-8"
@@ -27870,8 +27220,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "vvW" = (
 /obj/structure/chair/pew/left{
-	dir = 8;
-	icon_state = "pewend_left"
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -27893,12 +27242,10 @@
 /area/nsv/weapons/fore)
 "vwz" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay)
@@ -27908,8 +27255,7 @@
 	req_one_access_txt = "5"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -27946,11 +27292,9 @@
 /turf/open/floor/monotile,
 /area/janitor)
 "vyv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/closed/wall/steel,
-/area/nsv/weapons/fore)
+/obj/structure/closet/radiation,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "vzA" = (
 /obj/item/toy/figure/clown,
 /obj/structure/table/glass,
@@ -27987,8 +27331,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "vBC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/structure/closet,
 /obj/item/stock_parts/manipulator,
@@ -27997,9 +27340,7 @@
 "vBX" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "vCN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28017,9 +27358,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "vDc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28050,24 +27389,24 @@
 /obj/effect/turf_decal/tile/ship/full/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
+"vEV" = (
+/obj/machinery/chem_heater,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile/dark,
+/area/medical/chemistry)
 "vEW" = (
 /obj/machinery/computer/ship/fighter_controller{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/open/floor/carpet/purple,
 /area/nsv/crew_quarters/heads/maa)
 "vFs" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/plasteel/grid/mono,
@@ -28101,9 +27440,7 @@
 	pixel_y = 26
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "vHs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -28143,20 +27480,17 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "vJp" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -28165,17 +27499,17 @@
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame1/central)
 "vJC" = (
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
+	},
+/obj/machinery/computer/cloning{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/medical/genetics)
 "vKb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -28193,16 +27527,14 @@
 /area/nsv/crew_quarters/heads/maa)
 "vKG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1;
-	icon_state = "scrub_map_on-3"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hydroponics)
 "vKW" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment,
@@ -28214,17 +27546,13 @@
 "vLA" = (
 /obj/machinery/pool_filter,
 /turf/open/indestructible/sound/pool/end,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "vLI" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28267,12 +27595,10 @@
 /area/maintenance/nsv/deck2/port)
 "vNm" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame2/central)
@@ -28304,10 +27630,9 @@
 /area/maintenance/nsv/deck2/port)
 "vPW" = (
 /obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "vQe" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /obj/machinery/door/poddoor/shutters/ship/preopen{
@@ -28322,18 +27647,26 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "vQA" = (
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "vQF" = (
 /obj/machinery/lazylift_button,
 /turf/closed/wall/steel,
 /area/shuttle/turbolift)
+"vRK" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/poddoor/shutters/ship{
+	id = "gaussgang";
+	name = "public gauss access shutters"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "vRP" = (
 /obj/structure/chair/stool,
 /obj/machinery/light/small{
@@ -28354,6 +27687,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile/dark,
 /area/engine/atmospherics_engine)
 "vSH" = (
@@ -28363,9 +27698,7 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "vSQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28381,6 +27714,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
+"vSR" = (
+/obj/structure/chair/comfy/gauss/east,
+/turf/open/floor/monotile,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "vTQ" = (
 /obj/machinery/door/window/northright,
 /obj/machinery/door/firedoor/border_only/directional/north,
@@ -28391,8 +27728,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating{
@@ -28404,9 +27740,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "vUF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28425,6 +27759,15 @@
 /obj/item/camera_film,
 /turf/open/floor/carpet/purple,
 /area/library)
+"vVM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/noslip/dark,
+/area/nsv/weapons/nuclear)
 "vWT" = (
 /turf/open/floor/monotile/dark/airless,
 /area/space/nearstation)
@@ -28449,9 +27792,7 @@
 	},
 /area/maintenance/nsv/deck2/port)
 "vYh" = (
-/obj/machinery/advanced_airlock_controller/directional/north{
-	pixel_y = 24
-	},
+/obj/machinery/advanced_airlock_controller/directional/north,
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -28471,9 +27812,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "vYN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/computer/ship/viewscreen,
@@ -28491,8 +27830,7 @@
 "vZU" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -28511,10 +27849,7 @@
 /turf/open/floor/monotile,
 /area/lawoffice)
 "wcz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/wood,
 /area/maintenance/nsv/deck2/port)
 "wcL" = (
@@ -28559,17 +27894,13 @@
 "weU" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
 	},
 /turf/open/floor/monotile,
 /area/medical/medbay/lobby)
@@ -28632,8 +27963,7 @@
 "whJ" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/sorting/mail{
@@ -28651,8 +27981,7 @@
 /area/janitor)
 "wiD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/carpet/blue,
@@ -28675,9 +28004,7 @@
 	},
 /obj/structure/chair/stool/bar,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "wlH" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/reinforced{
@@ -28743,8 +28070,7 @@
 "wng" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -28762,8 +28088,7 @@
 /area/nsv/weapons/fore)
 "wrS" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4;
-	icon_state = "borderhalf"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
@@ -28834,9 +28159,7 @@
 	req_one_access_txt = "69"
 	},
 /turf/open/floor/plating,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "wvN" = (
 /obj/structure/table/wood,
 /obj/item/storage/book/bible,
@@ -28868,8 +28191,7 @@
 "wwS" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/machinery/door/firedoor/border_only{
-	dir = 1;
-	icon_state = "door_open"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -28891,14 +28213,19 @@
 /obj/item/ship_weapon/ammunition/torpedo/hull_shredder,
 /obj/item/ship_weapon/ammunition/torpedo/hull_shredder,
 /obj/machinery/camera/autoname{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/open/floor/monotile/light,
 /area/nsv/weapons/fore)
 "wyb" = (
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "cmoshutter_pegasus";
+	name = "Office Shutters";
+	pixel_x = -26;
+	pixel_y = -6
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
@@ -28985,12 +28312,10 @@
 /area/maintenance/nsv/deck2/port)
 "wDf" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -29007,9 +28332,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "wDN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -29079,9 +28402,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "wFt" = (
 /turf/open/floor/engine/vacuum,
 /area/engine/atmospherics_engine)
@@ -29121,30 +28442,30 @@
 /obj/structure/sign/ship/smoking{
 	pixel_y = 32
 	},
+/obj/machinery/camera/autoname,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/medical)
 "wId" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/curtain/obscuring/grey,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/shutters/ship/preopen{
+	id = "cmoshutter_pegasus"
+	},
 /turf/open/floor/plating,
 /area/medical/cryo)
 "wIo" = (
 /obj/machinery/computer/bounty{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/carpet/ship,
 /area/quartermaster/storage)
 "wJm" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -29168,10 +28489,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "wLa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -29187,10 +28509,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/beacon,
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "wLR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/monotile/dark,
@@ -29263,8 +28584,7 @@
 /area/maintenance/nsv/deck2/starboard)
 "wNX" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 1;
-	icon_state = "morgue1"
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -29277,9 +28597,7 @@
 /obj/item/clothing/under/costume/soviet,
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "wPv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -29306,8 +28624,7 @@
 "wPz" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -29325,9 +28642,7 @@
 	dir = 10
 	},
 /turf/open/floor/monotile,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "wQl" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -29361,6 +28676,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile,
 /area/medical/chemistry)
 "wRa" = (
@@ -29372,11 +28688,16 @@
 	},
 /area/maintenance/nsv/deck2/starboard)
 "wRe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/closed/wall/steel,
-/area/crew_quarters/heads/cmo)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/nsv/deck2/port)
 "wRh" = (
 /obj/structure/cable{
 	icon_state = "4-10"
@@ -29450,12 +28771,10 @@
 /area/crew_quarters/dorms)
 "wUe" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29474,9 +28793,7 @@
 /obj/structure/chair/comfy/gauss/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "wWl" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box{
@@ -29534,17 +28851,13 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "wYg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/monotile/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "wYT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -29559,9 +28872,7 @@
 "wZs" = (
 /obj/structure/chair/comfy/gauss/east,
 /turf/open/floor/monotile,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "wZC" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/security_space_law,
@@ -29587,11 +28898,19 @@
 	dir = 5
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "xba" = (
 /obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/nsv/deck2/starboard)
+"xbc" = (
+/obj/item/camera_film{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/structure/closet/crate,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -29651,16 +28970,15 @@
 "xct" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8;
-	icon_state = "scrub_map_on-3"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel/grid/mono,
 /area/hallway/nsv/deck2/frame3/central)
 "xcU" = (
@@ -29674,8 +28992,7 @@
 /area/quartermaster/office)
 "xdA" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
@@ -29703,9 +29020,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "xdM" = (
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/machinery/light,
@@ -29719,9 +29034,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -29788,13 +29101,19 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
+"xhe" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/monotile/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "xhm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/quartermaster/office)
@@ -29859,8 +29178,7 @@
 "xml" = (
 /obj/structure/ladder,
 /obj/structure/fluff/support_beam{
-	dir = 4;
-	icon_state = "support_beam"
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/maintenance/nsv/deck2/port)
@@ -29874,6 +29192,9 @@
 "xnV" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
 "xof" = (
@@ -29888,11 +29209,8 @@
 /turf/open/floor/engine,
 /area/medical/cryo)
 "xon" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/grille,
 /obj/structure/window/reinforced,
+/obj/structure/grille,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "xoE" = (
@@ -29905,13 +29223,19 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/pool,
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "xpP" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/monotile,
 /area/crew_quarters/kitchen)
+"xpR" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/monotile,
+/area/hallway/nsv/deck2/frame1/central)
 "xqB" = (
 /turf/open/floor/monotile/dark/airless,
 /area/space)
@@ -29929,6 +29253,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
 "xrM" = (
@@ -29956,17 +29283,14 @@
 /obj/structure/table/reinforced,
 /obj/machinery/paystand,
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "xsz" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Chimp Storage";
 	req_one_access_txt = "9"
 	},
 /obj/machinery/door/firedoor/border_only{
-	dir = 4;
-	icon_state = "door_open"
+	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -29984,10 +29308,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/tech/grid,
 /area/quartermaster/warehouse)
 "xur" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -30013,19 +29337,14 @@
 /obj/machinery/computer/ship/munitions_computer/east,
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "xuO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "xvc" = (
 /obj/item/storage/toolbox/electrical,
 /obj/structure/table,
@@ -30052,9 +29371,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "xwh" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -30071,9 +29388,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "xwA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -30090,19 +29405,16 @@
 	name = "Garbage collection subsystem"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1;
-	icon_state = "vent_map_on-1"
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/janitor)
 "xxg" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 4;
-	icon_state = "bordercorner"
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 1;
-	icon_state = "bordercorner"
+	dir = 1
 	},
 /obj/machinery/computer/ship/viewscreen,
 /turf/open/floor/plasteel/grid/mono,
@@ -30120,14 +29432,11 @@
 /area/quartermaster/office)
 "xxw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/ship,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "xxx" = (
 /obj/item/switchblade,
 /turf/open/floor/plating,
@@ -30166,9 +29475,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "xzu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30222,11 +29529,9 @@
 /turf/open/floor/monotile,
 /area/medical/virology)
 "xzY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmospherics_engine)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/tech/grid,
+/area/quartermaster/warehouse)
 "xAs" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -30242,8 +29547,7 @@
 /area/lawoffice)
 "xAO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4;
-	icon_state = "vent_map_on-1"
+	dir = 4
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/theatre)
@@ -30272,6 +29576,14 @@
 	},
 /turf/open/floor/monotile,
 /area/medical/virology)
+"xBH" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons/gauss/battery/deck2/port)
 "xBV" = (
 /obj/machinery/ship_weapon/mac{
 	dir = 4;
@@ -30291,6 +29603,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/closet/radiation,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -30298,21 +29611,19 @@
 "xDG" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /turf/open/floor/plating,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "xEe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/monotile,
 /area/medical/medbay)
 "xEC" = (
@@ -30336,9 +29647,7 @@
 	},
 /obj/effect/turf_decal/pool,
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "xGp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30362,9 +29671,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "xHk" = (
 /obj/machinery/door/airlock/ship/security{
 	name = "Cargo Bay Security Post";
@@ -30385,11 +29692,9 @@
 /area/security/checkpoint/supply)
 "xHm" = (
 /obj/structure/chair/pew/left{
-	dir = 8;
-	icon_state = "pewend_left"
+	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/chapel{
@@ -30397,15 +29702,12 @@
 	},
 /area/chapel/main)
 "xHw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
 	},
+/obj/structure/grille,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/fore)
 "xIM" = (
@@ -30416,12 +29718,8 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "xIT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/sign/ship/securearea{
-	dir = 8;
-	icon_state = "securearea"
+	dir = 8
 	},
 /turf/closed/wall/steel,
 /area/nsv/weapons/fore)
@@ -30434,8 +29732,7 @@
 "xKa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4;
-	icon_state = "warningline_white"
+	dir = 4
 	},
 /turf/open/floor/monotile,
 /area/crew_quarters/kitchen)
@@ -30445,9 +29742,7 @@
 	dir = 4
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "xKm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/obscuring/grey,
@@ -30460,17 +29755,11 @@
 /turf/open/floor/monotile/dark,
 /area/medical/genetics)
 "xLG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/nsv/deck2/port)
+/turf/open/floor/plasteel/techmaint,
+/area/quartermaster/warehouse)
 "xLK" = (
 /turf/open/floor/monotile,
 /area/crew_quarters/kitchen)
@@ -30535,9 +29824,7 @@
 	dir = 1
 	},
 /turf/open/floor/monotile/dark,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "xRh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30560,15 +29847,13 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "intra ship intercom";
 	pixel_y = 26
 	},
 /turf/open/floor/carpet/green,
 /area/chapel/main)
 "xRM" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 1;
-	icon_state = "borderhalf"
+	dir = 1
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame3/central)
@@ -30639,6 +29924,13 @@
 /obj/structure/disposalpipe/trunk/multiz,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
+"xVX" = (
+/obj/structure/sign/ship/securearea{
+	dir = 4;
+	name = "WARNING: WEAR HEARING PROTECTION"
+	},
+/turf/closed/wall/steel,
+/area/nsv/weapons/gauss/battery/deck2/starboard)
 "xWf" = (
 /obj/machinery/button/door{
 	id = "gaussgang";
@@ -30646,9 +29938,7 @@
 	req_one_access_txt = "69"
 	},
 /turf/closed/wall/steel,
-/area/nsv/weapons/gauss{
-	name = "Gauss Battery"
-	})
+/area/nsv/weapons/gauss/battery/deck2/port)
 "xWu" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box{
@@ -30707,9 +29997,7 @@
 	icon_state = "nanotrasen_sign4"
 	},
 /turf/closed/wall/steel,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "xZJ" = (
 /obj/machinery/shower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -30733,9 +30021,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/bar{
-	name = "Mess Hall"
-	})
+/area/crew_quarters/bar/mess_hall)
 "yaL" = (
 /obj/structure/table/reinforced,
 /obj/item/instrument/eguitar,
@@ -30757,13 +30043,10 @@
 	},
 /obj/effect/turf_decal/tile/ship/full/blue,
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "yaP" = (
 /obj/effect/turf_decal/tile/ship/green{
-	dir = 8;
-	icon_state = "bordercorner"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -30780,9 +30063,6 @@
 	},
 /turf/open/floor/monotile,
 /area/hallway/secondary/exit/departure_lounge)
-"ybv" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/nsv/deck1/port)
 "ybV" = (
 /obj/machinery/power/apc/auto_name/north{
 	pixel_y = 24
@@ -30798,8 +30078,7 @@
 /area/chapel/office)
 "yca" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8;
-	icon_state = "warningline"
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -30835,8 +30114,7 @@
 /area/maintenance/nsv/deck2/port)
 "ydw" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 8;
-	icon_state = "borderhalf"
+	dir = 8
 	},
 /turf/open/floor/monotile,
 /area/hallway/nsv/deck2/frame1/central)
@@ -30856,9 +30134,7 @@
 	dir = 8
 	},
 /turf/open/floor/monotile/light,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "yel" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
 /turf/open/floor/monotile,
@@ -30934,13 +30210,13 @@
 /area/crew_quarters/heads/cmo)
 "yjU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 8;
-	icon_state = "vent_map_on-1"
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/noslip/dark,
-/area/nsv/weapons{
-	name = "Nuclear Silo"
-	})
+/area/nsv/weapons/nuclear)
 "yjY" = (
 /obj/structure/table,
 /obj/item/grenade/chem_grenade/cleaner{
@@ -30994,9 +30270,7 @@
 	dir = 6
 	},
 /turf/open/floor/monotile,
-/area/crew_quarters/fitness{
-	name = "Pool"
-	})
+/area/crew_quarters/fitness/pool_area)
 "yko" = (
 /obj/machinery/computer/lore_terminal,
 /turf/open/floor/monotile,
@@ -49174,7 +48448,7 @@ iAt
 iAt
 mSy
 jRS
-lyy
+jdZ
 iAt
 vWT
 vWT
@@ -49940,7 +49214,7 @@ erR
 erR
 erR
 erR
-erR
+bvI
 erR
 erR
 erR
@@ -50395,12 +49669,12 @@ ihx
 ihx
 gJx
 oyC
-omS
+cDc
 wcz
-omS
+edW
 pOb
-raT
-sOK
+olk
+oyX
 gJx
 nFD
 oTe
@@ -50462,7 +49736,7 @@ fki
 tWF
 naj
 jRS
-cdQ
+nGv
 cdQ
 aXl
 cdQ
@@ -50976,7 +50250,7 @@ aEK
 tWF
 naj
 jRS
-gdz
+ueD
 cdQ
 bFm
 bFm
@@ -51167,7 +50441,7 @@ ihx
 gJx
 gJx
 gJx
-xLG
+gJx
 gJx
 gJx
 enp
@@ -51423,9 +50697,9 @@ ihx
 ihx
 vWT
 gJx
-dYJ
+djo
 sYA
-ukz
+iAh
 dYJ
 kjb
 ukz
@@ -51953,7 +51227,7 @@ dht
 dCt
 dCt
 lqF
-msj
+wRe
 xDb
 amg
 pCA
@@ -51998,10 +51272,10 @@ jyo
 sgY
 bYg
 xrc
-xrc
+xhe
 wmn
 erR
-erR
+ePP
 tBz
 jzM
 jVr
@@ -52485,9 +51759,9 @@ lgs
 lgs
 mAS
 snN
-occ
-gTb
-occ
+ucG
+nmx
+vVM
 nDr
 ege
 occ
@@ -52510,9 +51784,9 @@ qVp
 jVr
 dvr
 lHw
-xJe
-xJe
-tbV
+hhL
+jHm
+tRs
 pnV
 qcz
 jVr
@@ -53003,7 +52277,7 @@ axT
 aGU
 mAg
 owb
-owb
+gCb
 owb
 cnG
 aGU
@@ -53231,7 +52505,7 @@ vxv
 kBW
 buv
 mUn
-kBW
+tVL
 kBW
 xfx
 kxD
@@ -53515,8 +52789,8 @@ qVS
 pIh
 wKP
 lgs
-vyv
-srV
+lgs
+lgs
 xIT
 lgs
 lgs
@@ -54500,7 +53774,7 @@ pcO
 dLU
 vWT
 daR
-eRn
+cwm
 idX
 qEV
 qEV
@@ -54757,7 +54031,7 @@ pcO
 dLU
 vWT
 daR
-iAh
+eRn
 nFe
 kjJ
 lpM
@@ -55065,15 +54339,15 @@ hvL
 lgs
 gJG
 cWC
-oke
-oke
+hrO
+hrO
 rkd
-oke
-oke
-sxY
-oke
-oke
-oke
+hrO
+hrO
+xVX
+hrO
+hrO
+hrO
 sdm
 new
 gCW
@@ -55303,7 +54577,7 @@ rtl
 jMn
 sTc
 xWf
-uVA
+xBH
 dDz
 exB
 sdj
@@ -55322,7 +54596,7 @@ hvL
 lgs
 gJG
 cWC
-oke
+hrO
 jAo
 wDg
 gaX
@@ -55330,7 +54604,7 @@ eLv
 vYz
 aqk
 dsm
-xWf
+fDR
 aAS
 jXW
 rgC
@@ -55557,10 +54831,10 @@ mOL
 kOi
 gzT
 bCa
-yhO
+duo
 eVf
-kFF
-tPs
+lMH
+bZr
 wZs
 tPs
 wZs
@@ -55579,15 +54853,15 @@ hvL
 lgs
 gJG
 cWC
-oke
-nKi
+hrO
+eiS
 cyM
-oke
-wZs
+hrO
+vSR
 gMG
-wZs
+vSR
 rFz
-psb
+ahO
 diO
 pTB
 qVp
@@ -55836,18 +55110,18 @@ lgs
 lgs
 gJG
 cWC
-oke
-nKi
+hrO
+eiS
 cyM
-oke
-uym
+hrO
+tju
 gMG
-uym
-tPs
-kFF
+tju
+jGl
+vRK
 sdm
-new
-gCW
+efY
+amj
 uFk
 avJ
 iEt
@@ -56093,15 +55367,15 @@ wNb
 lgs
 fqH
 cWC
-oke
-nKi
+hrO
+eiS
 bgO
-oke
-kWe
+hrO
+pRo
 eUK
-kWe
-tPs
-kFF
+jcj
+jGl
+vRK
 sdm
 new
 nbg
@@ -56350,15 +55624,15 @@ lgs
 wrr
 jOL
 obD
-oke
-eKs
+hrO
+slc
 bsR
-oke
+hrO
 rah
-bYW
-wZs
-tPs
-kFF
+vkU
+vSR
+jGl
+vRK
 sdm
 new
 gCW
@@ -56607,15 +55881,15 @@ hzV
 lgs
 bPb
 ovG
-oke
-nKi
+hrO
+eiS
 cyM
-oke
+hrO
 gwg
 pBk
-rxe
+bDP
 hfC
-bLn
+sqh
 eaE
 feu
 gCW
@@ -56864,15 +56138,15 @@ aOf
 lgs
 gJG
 cWC
-oke
-nKi
+hrO
+eiS
 cyM
-oke
-uym
+hrO
+tju
 eLq
-uym
+tju
 eLq
-kFF
+vRK
 sdm
 ppo
 hLn
@@ -57121,15 +56395,15 @@ xBV
 lgs
 gJG
 cWC
-oke
-nKi
+hrO
+eiS
 cyM
-oke
-tkH
+hrO
+kqE
 eLq
-tkH
+kqE
 eLq
-bvx
+coQ
 nnJ
 mbU
 qyk
@@ -57360,7 +56634,7 @@ diJ
 rSR
 oke
 mmS
-uVA
+bhW
 mZd
 uVA
 nvn
@@ -57378,7 +56652,7 @@ hvL
 lgs
 gJG
 cWC
-oke
+hrO
 cyx
 cjX
 pqN
@@ -57386,7 +56660,7 @@ aYD
 cHn
 pdO
 etV
-oke
+hrO
 dYX
 pnx
 gCW
@@ -57635,15 +56909,15 @@ gYA
 lgs
 gJG
 cWC
-oke
-oke
+hrO
+hrO
 ccl
-oke
-oke
-nus
-oke
-oke
-oke
+hrO
+hrO
+onH
+hrO
+hrO
+hrO
 mQC
 pnx
 gCW
@@ -58906,8 +58180,8 @@ nKZ
 iZK
 vZU
 fdJ
-fdJ
-vcE
+kmQ
+ola
 tKK
 qiy
 udN
@@ -58922,7 +58196,7 @@ gzU
 lCa
 tKK
 jTm
-lTM
+nMS
 xct
 wPz
 tme
@@ -60180,7 +59454,7 @@ pkT
 hJk
 cpx
 moC
-jnR
+xLG
 kmd
 bCa
 yhO
@@ -60437,7 +59711,7 @@ cpx
 hJk
 cpx
 moC
-jnR
+xLG
 kmd
 jrT
 nJJ
@@ -60692,8 +59966,8 @@ cKy
 xtc
 xtc
 vqD
-moC
-moC
+xzY
+xzY
 fDG
 kmd
 jrT
@@ -61724,8 +60998,8 @@ oYE
 sZS
 brR
 lAu
-gqi
-yhO
+xpR
+fOA
 cMF
 oTg
 wYU
@@ -61962,7 +61236,7 @@ dLU
 gJx
 bqq
 sJF
-olk
+qFI
 tvu
 vfA
 vfA
@@ -61971,7 +61245,7 @@ vfA
 vfA
 vfA
 vfA
-olk
+qFI
 ijy
 ozO
 dfe
@@ -62029,9 +61303,9 @@ nSR
 hWj
 xag
 jbR
-gRJ
+rVB
 mFX
-lpU
+dHg
 pne
 bDw
 fKT
@@ -62267,7 +61541,7 @@ gdz
 wGR
 qAj
 qYi
-qYi
+pRE
 qYi
 wGR
 cCH
@@ -62287,8 +61561,8 @@ qGU
 tau
 jbR
 psL
-gRJ
-cdQ
+xbc
+xhZ
 kfq
 gRJ
 cdQ
@@ -62743,7 +62017,7 @@ vfA
 tvu
 cbO
 qFI
-dYJ
+ujC
 uaH
 dfe
 glj
@@ -63000,7 +62274,7 @@ vfA
 tvu
 cbO
 qFI
-dYJ
+djo
 nFJ
 dfe
 dfm
@@ -63257,7 +62531,7 @@ vfA
 tvu
 cbO
 qFI
-dYJ
+vyv
 uaH
 dfe
 fvO
@@ -63757,7 +63031,7 @@ ihx
 ihx
 vWT
 gJx
-ybv
+gJx
 gJx
 gJx
 uRg
@@ -65867,7 +65141,7 @@ tzg
 fkP
 vJC
 baB
-nsU
+jGT
 ocF
 qnr
 uFg
@@ -66124,7 +65398,7 @@ tzg
 xwh
 xbk
 wFK
-jGT
+nsU
 weU
 qnr
 lCp
@@ -66383,17 +65657,17 @@ qdt
 fPd
 jxZ
 qiY
-xAs
-fdh
-qnr
-kfo
-vQe
-cMg
-awO
-joA
+fHc
+tOv
+fKw
+ajF
+bRq
+vEV
+kdH
+cQv
 wQT
-pqu
-hCh
+tdI
+hVI
 miL
 raB
 xxx
@@ -66907,7 +66181,7 @@ joA
 iXV
 dpS
 xrM
-hCh
+pkj
 kxv
 raB
 bDw
@@ -68430,8 +67704,8 @@ bex
 tws
 jRj
 llT
-sir
-wRe
+tUX
+jRj
 uDm
 hRd
 rZf
@@ -69184,7 +68458,7 @@ gJx
 sDg
 sDg
 gJx
-ksC
+erT
 tKn
 sVT
 ipR
@@ -69441,7 +68715,7 @@ gJx
 gJx
 gJx
 gJx
-qhF
+dKm
 tKn
 sVT
 gWh
@@ -69453,7 +68727,7 @@ bvf
 wYc
 ydV
 xwc
-xwc
+pik
 tLx
 sxV
 qOG
@@ -72040,7 +71314,7 @@ jVr
 six
 gRJ
 raB
-orb
+dlh
 nLF
 wAj
 ejN
@@ -72523,8 +71797,8 @@ tXf
 iuj
 tlG
 sRR
-dYJ
-iGH
+xuF
+njZ
 ulu
 thn
 sFY
@@ -73053,9 +72327,9 @@ tzI
 fSU
 ulu
 wyr
-jOf
-gRJ
-jOf
+sWN
+nyt
+pXX
 cdQ
 jOf
 gRJ
@@ -73307,7 +72581,7 @@ uPD
 thE
 vVs
 miW
-tVL
+tzI
 ofe
 whr
 bFm
@@ -76675,10 +75949,10 @@ nXS
 nXS
 nXS
 lvN
-oyX
-cwm
-cwm
-xzY
+nXS
+nXS
+nXS
+nXS
 nXS
 nXS
 nXS
@@ -76932,7 +76206,7 @@ rSM
 nXS
 nXS
 rLj
-ujC
+nXS
 ulL
 nXS
 xBn
@@ -78220,7 +77494,7 @@ nXS
 aLn
 nXS
 nXS
-cDc
+nXS
 nXS
 nXS
 nXS
@@ -78476,8 +77750,8 @@ xdP
 eTL
 rjd
 gyz
-roJ
-edW
+cdQ
+bFm
 vWT
 bFm
 bFm
@@ -78986,7 +78260,7 @@ kBs
 fay
 crJ
 pVh
-djo
+jVr
 cdQ
 cdQ
 jVr

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3115,6 +3115,7 @@
 #include "nsv13\code\datums\traits\negative.dm"
 #include "nsv13\code\game\area\aetherwhisp.dm"
 #include "nsv13\code\game\area\hammerhead.dm"
+#include "nsv13\code\game\area\pegasus.dm"
 #include "nsv13\code\game\gamemodes\pvp\pvp.dm"
 #include "nsv13\code\game\general_quarters\damage.dm"
 #include "nsv13\code\game\general_quarters\squad.dm"

--- a/nsv13/code/game/area/pegasus.dm
+++ b/nsv13/code/game/area/pegasus.dm
@@ -1,0 +1,31 @@
+/area/nsv/weapons/gauss/battery/deck1/port
+	name = "Gauss Battery Deck 1 Port"
+
+/area/nsv/weapons/gauss/battery/deck1/starboard
+	name = "Gauss Battery Deck 1 Starboard"
+
+/area/nsv/weapons/gauss/battery/deck2/port
+	name = "Gauss Battery Deck 2 Port"
+
+/area/nsv/weapons/gauss/battery/deck2/starboard
+	name = "Gauss Battery Deck 2 Starboard"
+
+/area/nsv/weapons/nuclear
+	name = "Nuclear Silo"
+
+/area/crew_quarters/bar/mess_hall
+	name = "Mess Hall"
+
+/area/crew_quarters/fitness/pool_area
+	name = "Pool"
+
+/area/crew_quarters/heads/xo
+	name = "Executive Officer's Office"
+	icon_state = "hop_office"
+
+/area/nsv/hanger/notkmcstupidhanger/hangar/squad_hangar
+	name = "Squad Hangar Bay"
+
+/area/bridge/cic
+	name = "CIC"
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The following changes were made: 

- Nuclear silo has 2 air alarms for the same area
- Please write out "to" instead of ussing a text based arrow to label pumps. (To handle gas pumps and volume pumps without manually search the ship, use strongdmm Find by Instance)
- Match hangar locker contents. Add 2 oxygen lockers to Deck 1 port hangar. Add 2 welding supplies lockers to Deck 1 starboard hangar. 
- No tool storage was found on either deck. Deck 1 has been selected to add tool storage instead of Deck 2, as it has more opportunities to convert maintenance to a new room.
- Check 2 cloning setups ingame and troubleshoot 
- CMO office has no shutters
- Gauss bay Deck 1 port missing an APC
- Gauss bay Deck 2 port and starboard missing an APC
- Fix varediting areas with custom names, write custom area paths in code
- Add more fire closets
- Add more oxygen closets
- Add more radiation closets 
- Check for doublepipes
- Remove scrubbers loop doublepipe at pegasus1.dmm X170, Y139
- Remove scrubbers loop doublepipe at pegasus1.dmm X187, Y106
- Remove scrubbers loop doublepipe at pegasus1.dmm X104, Y67
- Remove scrubbers loop doublepipe at pegasus1.dmm X105, Y122
- Remove supply loop doublepipe at pegasus1.dmm X104, Y143
- Check for disconnected atmos pipes 
- Resolve atmospherics oxygen gas filter, disconnected 
- Remove sneaky hidden supply pipes under figher maglaunchers 
- Check for disconnected wires
- Resolved several extra/useless cable pieces, cables leading nowhere, machinery expecting connected cables but had none, and redundant wiring with too many connections in one tile. Excluding loss and stickbug 
- Check for disconnected disposals 
- Remove disposals doublepipe at pegasus2.dmm X125, Y108
- Remove disposals doublepipe at pegasus2.dmm X109, Y091
- Remove disposals doublepipe at pegasus1.dmm X129, Y123
- Fix disposals garbage collection room, with recycler and mass launcher not connecting properly to the ship disposals loop
- Added a missing wrapped objects disposal filter to cargo
- Check for disposals doublepipe
- No tinyfans were found on search 
- Resolve wall wires
- Only 2 wall wires were found, resolved 
- Resolve wall pipes where necessary, move pipes or make them visible on top of walls 
- Changed a few layer manifolds in atmospherics to visible, to appear over walls 
- Check camera coverage ingame 
- Added a camera to Deck 1 port hangar bay, to fill a gap
- Added a camera to bottom right atmospherics, to fill a gap
- Added a camera to medical smokeroom
- Added a camera to hydroponics backroom
- Added a camera to cargobay, to fill a gap
- Adjusted mining storage camera to fill a gap be
tween cargobay and mining storage
- Added a camera to medical treatment hallway, to fill a gap
- Check active roundstart turfs and resolve them 
- Resolved a couple area mismatches, where a single tile inexplicably appeared in an area it shouldn't be
- Room essentials added: 
- Added a few more public newscasters in various departments
- Added a few public sinks
- Added 3 tracking beacons, to departures, cafeteria and medical lobby

New ship images

Pegasus Deck 1 (pegasus1.dmm)
![pegasusfixes-deck1](https://user-images.githubusercontent.com/22532898/93171722-d97d4d00-f6e6-11ea-9541-bd537c1cdcf4.png)

Pegasus Deck 2 (pegasus2.dmm)
![pegasusfixes-deck2](https://user-images.githubusercontent.com/22532898/93171727-deda9780-f6e6-11ea-99b6-5671bdae2dae.png)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
