### PR TITLE
Syndicate radios now spawn only hearing common and syndicate channels

### DIFF
--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -148,10 +148,10 @@
 				if(R.can_receive(frequency, levels))
 					radios += R
 
-			// Syndicate radios can hear all well-known radio channels
+			// Universal Decryption radios can hear all well-known radio channels
 			if (num2text(frequency) in GLOB.reverseradiochannels)
 				for(var/obj/item/radio/R in GLOB.all_radios["[FREQ_SYNDICATE]"])
-					if(R.can_receive(FREQ_SYNDICATE, list(R.z)))
+					if(R.hearall == TRUE)
 						radios |= R
 
 		if (TRANSMISSION_RADIO)
@@ -165,7 +165,9 @@
 			for(var/obj/item/radio/R in GLOB.all_radios["[frequency]"])
 				if(R.independent && R.can_receive(frequency, levels))
 					radios += R
-
+			// r syndicate
+				if(R.syndie && R.can_receive(frequency, levels))
+					radios += R
 	// From the list of radios, find all mobs who can hear those.
 	var/list/receive = get_mobs_in_radio_ranges(radios)
 

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -6,6 +6,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/translate_binary = FALSE
 	var/syndie = FALSE
+	var/hearall = FALSE
 	var/independent = FALSE
 	var/list/channels = list()
 
@@ -27,7 +28,13 @@
 	name = "syndicate encryption key"
 	icon_state = "syn_cypherkey"
 	channels = list(RADIO_CHANNEL_SYNDICATE = 1)
-	syndie = TRUE//Signifies that it de-crypts Syndicate transmissions
+	syndie = TRUE
+
+/obj/item/encryptionkey/hearall
+	name = "universal decryption key"
+	icon_state = "bin_cypherkey"
+	channels = list(RADIO_CHANNEL_SYNDICATE = 1)
+	hearall = TRUE
 
 /obj/item/encryptionkey/binary
 	name = "binary translator key"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -85,7 +85,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 /obj/item/radio/headset/syndicate/alt //undisguised bowman with flash protection
 	name = "syndicate headset"
-	desc = "A syndicate headset that can be used to hear all radio frequencies. Protects ears from flashbangs."
+	desc = "A syndicate headset that can be used to hear syndicate frequencies. Protects ears from flashbangs."
 	icon_state = "syndie_headset"
 	item_state = "syndie_headset"
 	bang_protect = 1
@@ -324,6 +324,8 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 
 		if(keyslot2.translate_binary)
 			translate_binary = TRUE
+		if(keyslot2.hearall)
+			hearall = TRUE
 		if(keyslot2.syndie)
 			syndie = TRUE
 		if (keyslot2.independent)

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -80,7 +80,7 @@
 	if(!listening)
 		return FALSE
 	if(freq == FREQ_SYNDICATE)
-		if(!(syndie))
+		if(!(syndie || hearall))
 			return FALSE//Prevents broadcast of messages over devices lacking the encryption
 
 	return TRUE
@@ -141,11 +141,11 @@
 /obj/item/radio/intercom/directional/south
 	dir = SOUTH
 	pixel_y = -28
-	
+
 /obj/item/radio/intercom/directional/west
 	dir = WEST
 	pixel_x = -27
-	
+
 /obj/item/radio/intercom/directional/east
 	dir = EAST
 	pixel_x = 27 //NSV13 End

--- a/code/modules/admin/verbs/borgpanel.dm
+++ b/code/modules/admin/verbs/borgpanel.dm
@@ -164,7 +164,10 @@
 				if (!borg.radio.keyslot) // There's no encryption key. This shouldn't happen but we can cope
 					borg.radio.channels -= channel
 					if (channel == RADIO_CHANNEL_SYNDICATE)
-						borg.radio.syndie = FALSE
+						if(borg.radio.syndie == TRUE)
+							borg.radio.syndie = FALSE
+						if(borg.radio.hearall == TRUE)
+							borg.radio.hearall = FALSE
 					else if (channel == "CentCom")
 						borg.radio.independent = FALSE
 				else

--- a/code/modules/admin/verbs/borgpanel.dm
+++ b/code/modules/admin/verbs/borgpanel.dm
@@ -164,9 +164,9 @@
 				if (!borg.radio.keyslot) // There's no encryption key. This shouldn't happen but we can cope
 					borg.radio.channels -= channel
 					if (channel == RADIO_CHANNEL_SYNDICATE)
-						if(borg.radio.syndie == TRUE)
+						if(borg.radio.syndie)
 							borg.radio.syndie = FALSE
-						if(borg.radio.hearall == TRUE)
+						if(borg.radio.hearall)
 							borg.radio.hearall = FALSE
 					else if (channel == "CentCom")
 						borg.radio.independent = FALSE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1107,6 +1107,7 @@
 	if(radio && AI.radio) //AI keeps all channels, including Syndie if it is a Traitor
 		if(AI.radio.syndie)
 			radio.make_syndie()
+			radio.syndie = TRUE
 		radio.subspace_transmission = TRUE
 		radio.channels = AI.radio.channels
 		for(var/chan in radio.channels)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1616,10 +1616,10 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	cost = 2
 
 /datum/uplink_item/device_tools/encryptionkey
-	name = "Syndicate Encryption Key"
+	name = "Universal Decryption Key"
 	desc = "A key that, when inserted into a radio headset, allows you to listen to all station department channels \
 			as well as talk on an encrypted Syndicate channel with other agents that have the same key."
-	item = /obj/item/encryptionkey/syndicate
+	item = /obj/item/encryptionkey/hearall
 	cost = 2
 	surplus = 75
 	restricted = TRUE


### PR DESCRIPTION
You're going to want to remove the telecomms relay on the syndicate ship too or they will still be able to hear common (and talk on it). Other than that it does 100% of the things.
Possible side effects include:
intercoms with the syndie trait not working (made sure they did but still)
acute telecommunication code awareness
holy fuck it's bad
why is it so much spaghetti
the centcom and syndie radio literally bypasses all telecomms machines they're the perfect radios (yes this legit means they're faster to talk through cause all other signals have a sleep function somewhere in tcomms jank)
