### PR TITLE
Collision physics + unit circle standardization

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -166,7 +166,9 @@ generally it would be used like so:
 NOTE: it checks usr! not src! So if you're checking somebody's rank in a proc which they did not call
 you will have to do something like if(client.rights & R_ADMIN) yourself.
 */
-/proc/check_rights(rights_required, show_msg=1)
+/proc/check_rights(rights_required, show_msg=1, ignore_no_usr = FALSE)
+	if(!usr && ignore_no_usr) //hack for when this is called by a stack without a usr
+		return 1
 	if(usr?.client)
 		if (check_rights_for(usr.client, rights_required))
 			return 1

--- a/nsv13.dme
+++ b/nsv13.dme
@@ -3841,6 +3841,7 @@
 #include "nsv13\code\modules\collision\collision_response.dm"
 #include "nsv13\code\modules\collision\matrixvector.dm"
 #include "nsv13\code\modules\collision\shape.dm"
+#include "nsv13\code\modules\collision\vector2d.dm"
 #include "nsv13\code\modules\crew_objectives\engineering_objectives.dm"
 #include "nsv13\code\modules\donator\donator_component.dm"
 #include "nsv13\code\modules\events\weather\deadly_radiation_storm.dm"

--- a/nsv13/code/modules/overmap/overmapJS/overmap_MC_subsystem.dm
+++ b/nsv13/code/modules/overmap/overmapJS/overmap_MC_subsystem.dm
@@ -16,7 +16,7 @@ PROCESSING_SUBSYSTEM_DEF(JSOvermap)
 	instance(/datum/overmap/ship/syndicate/cruiser, new /datum/vec5(400, 1000, 1, 90, 0))
 
 /datum/controller/subsystem/processing/JSOvermap/proc/instance(type, datum/vec5/position)
-	var/datum/overmap/OM = register(new type(position.x, position.y, position.z, position.angle, position.velocity))
+	var/datum/overmap/OM = register(new type(position.x, position.y, position.z, position.angle, position.velocity.x, position.velocity.y))
 	return OM
 
 /datum/controller/subsystem/processing/JSOvermap/proc/get_overmap(z)
@@ -73,7 +73,7 @@ PROCESSING_SUBSYSTEM_DEF(JSOvermap)
 			rotation_power = O.rotation_power,
 			sensor_range = O.get_sensor_range(),
 			armour_quadrants = quads,
-			position = list(O.position.x, O.position.y, O.position.z, O.position.angle, O.position.velocity)
+			position = list(O.position.x, O.position.y, O.position.z, O.position.angle, O.position.velocity.ln(), O.position.velocity.x, O.position.velocity.y)
 		)
 		.["physics_world"] += list(data)
 

--- a/nsv13/code/modules/overmap/overmapJS/overmap_MC_subsystem.dm
+++ b/nsv13/code/modules/overmap/overmapJS/overmap_MC_subsystem.dm
@@ -16,8 +16,8 @@ PROCESSING_SUBSYSTEM_DEF(JSOvermap)
 	instance(/datum/overmap/ship/syndicate/cruiser, new /datum/vec5(400, 1000, 1, 90, 0))
 
 /datum/controller/subsystem/processing/JSOvermap/proc/batch_grid()
-	for (var/i=0, i<10, i++)
-		for(var/j=0, j<10, j++)
+	for (var/i=0, i<3, i++)
+		for(var/j=0, j<3, j++)
 			if (i % 2)
 				instance(/datum/overmap/ship/player/cruiser, new /datum/vec5((i+1) * 800, (j+1) * 800, 1, 90, 0))
 			else

--- a/nsv13/code/modules/overmap/overmapJS/overmap_MC_subsystem.dm
+++ b/nsv13/code/modules/overmap/overmapJS/overmap_MC_subsystem.dm
@@ -15,6 +15,16 @@ PROCESSING_SUBSYSTEM_DEF(JSOvermap)
 	instance(/datum/overmap/ship/syndicate, new /datum/vec5(1000, 400, 1, 0, 0))
 	instance(/datum/overmap/ship/syndicate/cruiser, new /datum/vec5(400, 1000, 1, 90, 0))
 
+/datum/controller/subsystem/processing/JSOvermap/proc/batch_grid()
+	for (var/i=0, i<10, i++)
+		for(var/j=0, j<10, j++)
+			if (i % 2)
+				instance(/datum/overmap/ship/player/cruiser, new /datum/vec5((i+1) * 800, (j+1) * 800, 1, 90, 0))
+			else
+				instance(/datum/overmap/ship/syndicate/cruiser, new /datum/vec5((i+1) * 800, (j+1) * 800, 1, 90, 0))
+
+
+
 /datum/controller/subsystem/processing/JSOvermap/proc/instance(type, datum/vec5/position)
 	var/datum/overmap/OM = register(new type(position.x, position.y, position.z, position.angle, position.velocity.x, position.velocity.y))
 	return OM
@@ -108,7 +118,7 @@ PROCESSING_SUBSYSTEM_DEF(JSOvermap)
 	return GLOB.admin_state
 
 /datum/overmap_js_panel/ui_interact(mob/user, datum/tgui/ui)
-	if(!check_rights(0))
+	if(!check_rights(0, 1, TRUE)) //sometimes this is called by the physics engine, which means it won't have a usr
 		return
 	if(!active_ship)
 		active_ship = SSJSOvermap.physics_world[1]

--- a/nsv13/code/modules/overmap/overmapJS/overmap_js.dm
+++ b/nsv13/code/modules/overmap/overmapJS/overmap_js.dm
@@ -7,14 +7,14 @@
 	var/y = 0
 	var/z = 0
 	var/angle = 0
-	var/velocity = 0
+	var/datum/vector2d/velocity = null
 
-/datum/vec5/New(x,y,z,angle,velocity)
+/datum/vec5/New(x,y,z,angle,velocity_x, velocity_y)
 	src.x = x
 	src.y = y
 	src.z = z
 	src.angle = angle
-	src.velocity = velocity
+	src.velocity = new /datum/vector2d(velocity_x, velocity_y)
 
 /datum/armour_quadrant
 	var/integrity = 100
@@ -64,14 +64,16 @@
 	var/list/armour_quadrants = null
 	var/role = OVERMAP_ROLE_SECONDARY
 
+	var/restitution = 1 //"bounciness", as used for collisions. 1 = boingy boingy, 0 = no boingy
+
 
 /**
 	Constructor for overmap objects. Pre-bakes some maths for you and initialises processing.
 */
-/datum/overmap/New(x,y,z,angle,velocity)
+/datum/overmap/New(x,y,z,angle,velocity_x, velocity_y)
 	if(collision_positions == null)
 		collision_positions = GLOB.projectile_hitbox
-	position = new /datum/vec5(x,y,z,angle,velocity)
+	position = new /datum/vec5(x,y,z,angle,velocity_x, velocity_y)
 	//If the overmap JS subsystem does not contain our type's icon, add it.
 	var/icon/I = icon(icon,icon_state,SOUTH, frame=1)
 	if(!SSJSOvermap.overmap_icons["[src.type]"])
@@ -142,7 +144,7 @@
 	//TODO: magic number "10".
 	//We scromble the position so it originates from the centre of the ship.
 	for(var/i = 1; i <= burst_size; i++)
-		var/datum/overmap/projectile/O = new projectile_type(position.x + (collision_radius/2),position.y + (collision_radius/2), position.z, angle, position.velocity)
+		var/datum/overmap/projectile/O = new projectile_type(position.x + (collision_radius/2),position.y + (collision_radius/2), position.z, angle, position.velocity.ln())
 		O.position.velocity += O.speed
 		O.faction = faction
 		SSJSOvermap.register(O)
@@ -166,7 +168,7 @@
 	//radians = TORADIANS(position.angle)
 	//Okay.. BYOND cos uses degrees, not radians. Good to know!
 	cos_r = cos(position.angle)
-	sin_r = sin(position.angle)
+	sin_r = -sin(position.angle)
 	//TODO: Mark everything dirty when we rotate, as we change heading.
 	SEND_SIGNAL(src, COMSIG_JS_OVERMAP_UPDATE, src)
 
@@ -178,13 +180,17 @@
 /datum/overmap/proc/thrust(dir)
 	switch(dir)
 		if(1)
-			position.velocity += thruster_power
+			position.velocity.x += thruster_power * cos_r
+			position.velocity.y += thruster_power * sin_r
 		if(-1)
 			//TODO: unrealistic, OK for now
 			//position.velocity *= 0.99
-			position.velocity -= thruster_power
-			if(position.velocity < 0)
-				position.velocity = 0
+			position.velocity.x -= thruster_power * cos_r
+			position.velocity.y -= thruster_power * sin_r
+
+			if(position.velocity.ln() < 0)
+				position.velocity.x = 0
+				position.velocity.y = 0
 	//TODO: Mark everything dirty when we rotate, as we change heading.
 	SEND_SIGNAL(src, COMSIG_JS_OVERMAP_UPDATE, src)
 
@@ -194,8 +200,8 @@
 
 //TODO: game coords to canvas coords! major desync issues, here.
 /datum/overmap/process()
-	position.x -= cos_r * position.velocity
-	position.y -= sin_r * position.velocity
+	position.x += position.velocity.x //y is down but x points right as usual, so these have to be, er, this way.
+	position.y += position.velocity.y
 	physics2d.update()
 	on_move()
 

--- a/nsv13/code/modules/overmap/overmapJS/overmap_js.dm
+++ b/nsv13/code/modules/overmap/overmapJS/overmap_js.dm
@@ -168,7 +168,7 @@
 	//radians = TORADIANS(position.angle)
 	//Okay.. BYOND cos uses degrees, not radians. Good to know!
 	cos_r = cos(position.angle)
-	sin_r = -sin(position.angle)
+	sin_r = sin(position.angle)
 	//TODO: Mark everything dirty when we rotate, as we change heading.
 	SEND_SIGNAL(src, COMSIG_JS_OVERMAP_UPDATE, src)
 

--- a/nsv13/code/modules/overmap/overmapJS/overmap_js_physics.dm
+++ b/nsv13/code/modules/overmap/overmapJS/overmap_js_physics.dm
@@ -80,6 +80,7 @@ PROCESSING_SUBSYSTEM_DEF(physics_processing)
 				continue
 			if(body.collide(neighbour))
 				SEND_SIGNAL(SSJSOvermap, COMSIG_JS_OVERMAP_UPDATE, body.holder)
+				SEND_SIGNAL(SSJSOvermap, COMSIG_JS_OVERMAP_UPDATE, neighbour.holder)
 				to_chat(world, "BONK")
 
        //multiple collision avoidance. basically collisions and physics run on separate subsystems. it would be very good to change this rather soon

--- a/nsv13/code/modules/overmap/overmapJS/overmap_projectile.dm
+++ b/nsv13/code/modules/overmap/overmapJS/overmap_projectile.dm
@@ -47,7 +47,7 @@
 
 /datum/overmap/projectile/on_move()
 	..()
-	distance_travelled += position.velocity
+	distance_travelled += position.velocity.ln()
 	if(distance_travelled > range)
 		qdel(src)
 

--- a/tgui/packages/tgui/interfaces/JSOvermap.js
+++ b/tgui/packages/tgui/interfaces/JSOvermap.js
@@ -279,7 +279,7 @@ class overmapEntity{
   }
   rotate(dir){
     //TODO: bodge
-    this.angle -= this.rotation_power * dir;
+    this.angle += this.rotation_power * dir;
     this.r = (this.angle) * (Math.PI / 180);
   }
   thrust(dir){
@@ -604,10 +604,10 @@ export const JSOvermapGame = (props, context) => {
         let x = ship.x;
         let y = ship.y;
         if(x <= Camera.viewport.width+Camera.viewport.left && y <= Camera.viewport.height+Camera.viewport.top){
-          draw(ship.icon, ship.x, ship.y, ship.angle - 90);
+          draw(ship.icon, ship.x, ship.y, ship.angle + 90);
 
           if(ship.armour_quadrants.length > 0){
-            drawArmourQuadrants(ship.icon, ship.x, ship.y, 180, radians(ship.angle-90), ship.armour_quadrants, 0.8)
+            drawArmourQuadrants(ship.icon, ship.x, ship.y, 180, radians(ship.angle + 90), ship.armour_quadrants, 0.8)
           }
           if(ship.sensor_range > 0){
             drawCircle(ship.icon, ship.x, ship.y, ship.sensor_range);

--- a/tgui/packages/tgui/interfaces/JSOvermap.js
+++ b/tgui/packages/tgui/interfaces/JSOvermap.js
@@ -254,12 +254,14 @@ const interpolation_mult = target_fps/backend_fps;
 const tick_rate = backend_tick_rate / interpolation_mult;
 
 class overmapEntity{
-  constructor(x,y,z,angle,velocity, icon, thruster_power, rotation_power, sensor_range, armour_quadrants){
+  constructor(x,y,z,angle, velocity, velocity_x, velocity_y, icon, thruster_power, rotation_power, sensor_range, armour_quadrants){
     this.x = x;
     this.y = y;
     this.z = z;
     this.angle = angle;
-    this.velocity = velocity;
+    this.velocity = velocity
+    this.velocity_x = velocity_x;
+    this.velocity_y = velocity_y;
     this.icon = icon;
     this.thruster_power = thruster_power;
     this.rotation_power = rotation_power;
@@ -272,22 +274,24 @@ class overmapEntity{
   //They attempt to model where the ship "ought" to be, based on input.
   process(){
     //TODO: this calculation is off
-    this.x -= Math.cos(this.r) * (this.velocity/interpolation_mult);
-    this.y -= Math.sin(this.r) * (this.velocity/interpolation_mult);
+    this.x += (this.velocity_x/interpolation_mult);
+    this.y += (this.velocity_y/interpolation_mult);
   }
   rotate(dir){
     //TODO: bodge
-    this.angle += this.rotation_power * dir;
+    this.angle -= this.rotation_power * dir;
     this.r = (this.angle) * (Math.PI / 180);
   }
   thrust(dir){
     //TODO: bodge
     //this.velocity += this.thruster_power * dir;
     if(dir == 1){
-      this.velocity += this.thruster_power
+      this.velocity_x += Math.cos(this.r) * this.thruster_power
+      this.velocity_y += Math.sin(this.r) * this.thruster_power
     }
     else{
-      this.velocity -= this.thruster_power
+      this.velocity_x -= Math.cos(this.r) * this.thruster_power
+      this.velocity_y -= Math.sin(this.r) * this.thruster_power
       if(this.velocity < 0)
         this.velocity = 0
     }
@@ -315,7 +319,7 @@ export const JSOvermapGame = (props, context) => {
       let ship = data.physics_world[I];
       const sprite = new Image();
       sprite.src = `data:image/jpeg;base64,${ship.icon}`
-      world[I] = new overmapEntity(ship.position[0], ship.position[1], ship.position[2], ship.position[3], ship.position[4], sprite, ship.thruster_power, ship.rotation_power, ship.sensor_range, ship.armour_quadrants);
+      world[I] = new overmapEntity(ship.position[0], ship.position[1], ship.position[2], ship.position[3], ship.position[4], ship.position[5], ship.position[6], sprite, ship.thruster_power, ship.rotation_power, ship.sensor_range, ship.armour_quadrants);
       if(ship.active){
         active_ship = world[I];
       }
@@ -600,7 +604,7 @@ export const JSOvermapGame = (props, context) => {
         let x = ship.x;
         let y = ship.y;
         if(x <= Camera.viewport.width+Camera.viewport.left && y <= Camera.viewport.height+Camera.viewport.top){
-          draw(ship.icon, ship.x,ship.y, ship.angle-90);
+          draw(ship.icon, ship.x, ship.y, ship.angle - 90);
 
           if(ship.armour_quadrants.length > 0){
             drawArmourQuadrants(ship.icon, ship.x, ship.y, 180, radians(ship.angle-90), ship.armour_quadrants, 0.8)


### PR DESCRIPTION
This may break some things but it's worth it. Basically unit circle now properly orients, 0 being right, 90 being down, and so forth. It's flipped because y+ is down but now everything is consistent across overmap and in the backend. This is how Godot does it so I assume it's good.

Also adds collision physics, taken from https://research.ncl.ac.uk/game/mastersdegree/gametechnologies/physicstutorials/5collisionresponse/Physics%20-%20Collision%20Response.pdf

I'm using the impulse collision response, but in the future it could be good to try the second order "penalty model" if I could figure out to get that to work in javascript. Rigid body mechanics are also potentially on the table, where it's not just ping pong balls but rectangles hitting each other and spinning and stuff.

Big thing right now is desync. Not sure what's going on there but maybe kmc or someone else could take a look. JS seems to deviate from backend after a while, and it's only evident from switching view to update. Don't think collisions has anything to do with this.